### PR TITLE
Add staff users to Observer group on first login

### DIFF
--- a/designer/apps/core/__init__.py
+++ b/designer/apps/core/__init__.py
@@ -1,0 +1,3 @@
+""" Core app for designer """
+
+default_app_config = 'designer.apps.core.apps.CoreConfig'

--- a/designer/apps/core/apps.py
+++ b/designer/apps/core/apps.py
@@ -1,0 +1,10 @@
+""" app config for designer core """
+
+from django.apps import AppConfig
+
+
+class CoreConfig(AppConfig):
+    name = 'designer.apps.core'
+
+    def ready(self):
+        from . import signals  # pylint: disable=unused-variable

--- a/designer/apps/core/signals.py
+++ b/designer/apps/core/signals.py
@@ -1,0 +1,25 @@
+""" Signals sent by  Core Models """
+
+from django.db.models.signals import post_save
+from django.dispatch import receiver
+from django.contrib.auth.models import Group
+from .models import User
+
+# When a new user is created, this signal is actually fired 3 times for 3 seperate sources
+# * Once by wagtail
+# * Once for the edx_social_auth data
+# * Once more to update the last login
+# `created` will flip to false after the initial call, but before the edx data (ie: is_staff)
+# can be consumed. We cannot rely on it to tell us when the user is first being created.
+# Instead, we check to see if `update_fields` exists in kwargs.
+# `update_fields` will only exist when the user is already created, and does not exist when
+# the data from edx is populated. Essentially, its false for the first 2 steps in the flow,
+# but should always exist any time afterwards.
+@receiver(post_save, sender=User)
+def add_observer_group_to_staff(instance, **kwargs):
+    # if the user already exists, just return.
+    if kwargs['update_fields']:
+        return
+    if instance.is_staff:
+        observer_group = Group.objects.get(name='Observers')
+        instance.groups.add(observer_group)

--- a/designer/apps/core/tests/test_signals.py
+++ b/designer/apps/core/tests/test_signals.py
@@ -1,0 +1,37 @@
+""" Tests for Core Signals """
+
+from django.test import TestCase
+from django.contrib.auth.models import Group
+from django_dynamic_fixture import G
+from designer.apps.core.models import User
+
+
+class PostSaveTests(TestCase):
+    """ Tests for the post_save Signal """
+    # if a user has proper staff status, logs in for the first time, add them to the group.
+    def test_adds_user_to_observers_if_staff(self):
+        user = G(User, is_staff=True)
+        self.assertEqual(user.is_staff, True)
+        self.assertIn(Group.objects.get(name="Observers"), user.groups.all())
+
+    # if a user has no staff status, logs in for the first time, don't add the Observers group
+    def test_no_Observer_for_non_staff(self):
+        user = G(User, is_staff=False)
+        self.assertNotEqual(user.is_staff, True)
+        self.assertNotIn(Group.objects.get(name="Observers"), user.groups.all())
+
+    # Only give Observer status to staff on initial login.
+    # This is to prove the code that adds the user to the group does not run on
+    # every subsequent user save.
+    def test_no_Observer_after_initial_creation(self):
+        user = G(User, is_staff=False)
+        self.assertNotEqual(user.is_staff, True)
+        self.assertNotIn(Group.objects.get(name="Observers"), user.groups.all())
+        user.is_active = False
+        user.save()
+        # simulate new login
+        user.is_staff = True
+        user.is_active = True
+        user.save(update_fields=['last_login'])
+        self.assertEqual(user.is_staff, True)
+        self.assertNotIn(Group.objects.get(name="Observers"), user.groups.all())


### PR DESCRIPTION
When a user with staff logs in for the first time, they used to just see the word "unauthorized" on a blank page. Now, they will automatically be added to Observers, and see a blank CMS instead.

Users who have already tried to log into wagtail will **not** be added to the group automatically.