### PR TITLE
Redirect Add A Site link to site creation mgmt cmd

### DIFF
--- a/designer/urls.py
+++ b/designer/urls.py
@@ -41,6 +41,7 @@ urlpatterns = oauth2_urlpatterns + [
     url(r'^pages/', include(wagtail_urls)),
     url(r'^cms/login/$', core_views.wagtail_admin_access_check),
     url(r'^cms/logout/$', RedirectView.as_view(url='/logout/')),
+    url(r'^cms/sites/new/$', RedirectView.as_view(url='/cms/create_site/')),
     url(r'^cms/', include(wagtailadmin_urls)),
     url(r'^$', RedirectView.as_view(url='/cms/'))
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
Since adding things to the wagtail CMS is easy, but removing things is
hard, the quickest removal of the duplicate site creation page is to
redirect the generic one to the custom one.