### PR TITLE
Prevent child pages from being created if there is a mismatch in sibling page types

### DIFF
--- a/designer/apps/pages/models.py
+++ b/designer/apps/pages/models.py
@@ -16,6 +16,7 @@ from wagtail.wagtailcore.models import Page
 from wagtail.wagtaildocs.blocks import DocumentChooserBlock
 
 from designer.apps.branding.models import Branding
+from designer.apps.pages.utils import is_valid_child_page
 
 
 class IndexPage(Page):
@@ -57,6 +58,13 @@ class ProgramPage(Page):
         InlinePanel('program_documents', label="Program Documents", max_num=1),
         InlinePanel('branding', label="Program Page Branding", max_num=1),
     ]
+
+    @classmethod
+    def can_exist_under(cls, parent):
+        can_exist_under_parent = super(ProgramPage, cls).can_exist_under(parent)
+        parent_child_pages = parent.get_descendants()
+        is_valid_child = is_valid_child_page(cls, parent_child_pages)
+        return can_exist_under_parent and is_valid_child
 
 
 class ExternalProgramWebsite(models.Model):
@@ -214,6 +222,15 @@ class EnterprisePage(Page):
         FieldPanel('contact_email', classname="full"),
         InlinePanel('branding', label="Enterprise Page Branding", max_num=1),
     ]
+
+    @classmethod
+    def can_exist_under(cls, parent):
+        can_exist_under_parent = super(EnterprisePage, cls).can_exist_under(parent)
+        parent_child_pages = parent.get_descendants()
+        if parent_child_pages:
+            return False
+        is_valid_child = is_valid_child_page(cls, parent_child_pages)
+        return can_exist_under_parent and is_valid_child
 
 
 class EnterprisePageBranding(Branding):

--- a/designer/apps/pages/utils.py
+++ b/designer/apps/pages/utils.py
@@ -1,0 +1,21 @@
+""" Page utils """
+
+
+def is_valid_child_page(cls, parent_child_pages):
+    """
+    When adding a child page (e.g., ProgramPage, EnterprisePage), we want to ensure
+    only child pages of the same type can exist under their parent page.
+
+    For example:
+    - if the parent page has no children, the page would be a valid sibling.
+    - if the parent page already has a child page `ProgramPage`, then only
+      a new `ProgramPage` is valid under the parent page.
+
+    .. no_pii:
+    """
+    is_valid_child = True
+    for child_page in parent_child_pages:
+        if cls is not child_page.specific_class:
+            is_valid_child = False
+            break
+    return is_valid_child

--- a/designer/apps/pages/utils.py
+++ b/designer/apps/pages/utils.py
@@ -14,6 +14,6 @@ def is_valid_child_page(cls, parent_child_pages):
     .. no_pii:
     """
     for child_page in parent_child_pages:
-        if cls is not child_page.specific_class:
+        if not isinstance(child_page.specific, cls):
             return False
     return True

--- a/designer/apps/pages/utils.py
+++ b/designer/apps/pages/utils.py
@@ -13,9 +13,7 @@ def is_valid_child_page(cls, parent_child_pages):
 
     .. no_pii:
     """
-    is_valid_child = True
     for child_page in parent_child_pages:
         if cls is not child_page.specific_class:
-            is_valid_child = False
-            break
-    return is_valid_child
+            return False
+    return True


### PR DESCRIPTION
This PR prevents a site (`IndexPage`) from having both `EnterprisePage` and `ProgramPage` as children pages. Additionally, a site (`IndexPage`) is limited to a single `EnterprisePage` as a child page.

This approach prevents the appropriate type of page from being selected when clicking the "Add Child Page" button in the CMS. In an `IndexPage` already has a `ProgramPage` child, clicking "Add Child Page" will bring the user directly to the `ProgramPage` creation, as opposed to a page that allows the user to select `ProgramPage` or `EnterprisePage`.

Note: In `test_create_pages.py`, I moved the `_create_program_page_data` and `_create_enterprise_page_data` methods into `PageCreationMixin` so that both `ProgramPageCreationTests` and `EnterprisePageCreationTests` have access to those methods to be able to test creating a child page when a page of a different type already exists under a site.