### PR TITLE
BOM-1336: Fixed url configuration

### DIFF
--- a/designer/apps/api/urls.py
+++ b/designer/apps/api/urls.py
@@ -7,5 +7,5 @@ contain namespaces for the active versions of the API.
 from django.conf.urls import url, include
 
 urlpatterns = [
-    url(r'^v1/', include('designer.apps.api.v1.urls', namespace='v1')),
+    url(r'^v1/', include(('designer.apps.api.v1.urls', 'v1'))),
 ]


### PR DESCRIPTION
[BOM-1336](https://openedx.atlassian.net/browse/BOM-1336)

- One instance of warning will be removed by django upgrade to 2.0, as it is coming from django code
- Remaining URL warnings will be fixed by wagtail update.