### PR TITLE
BOM-1323 Updated wagtail to 2.6.2

### DIFF
--- a/requirements/base.in
+++ b/requirements/base.in
@@ -17,7 +17,7 @@ edx_rest_api_client
 mysqlclient
 pytz
 python-dateutil==2.8.0    # botocore has a <2.8.1 constraint. This is not a direct dependency and can be deleted (vs unpinned) when no longer needed
-wagtail==2.3     # wagtail>2.3 dropped support for django111
+wagtail==2.6.2     # wagtail>2.3 dropped support for django111
 zipp==1.2.0      # greater versions dropped Python 3.5 support
 mock<4.0.0      # mock>=4.0.0 dropped support for python3.5
 inflect<4.0.0   # inflect>=4.0.0 dropped support for python3.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -15,7 +15,7 @@ django-extensions==2.2.8  # via -r requirements/base.in
 django-modelcluster==4.4.1  # via wagtail
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-storages==1.9.1    # via -r requirements/base.in
-django-taggit==0.23.0     # via wagtail
+django-taggit==0.24.0     # via wagtail
 django-treebeard==4.3.1   # via wagtail
 django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
 django==1.11.29           # via -r requirements/base.in, django-cors-headers, django-storages, django-taggit, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
@@ -61,11 +61,12 @@ six==1.14.0               # via django-extensions, django-waffle, edx-auth-backe
 slumber==0.7.1            # via edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, edx-auth-backends
 social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
+sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
 unidecode==1.1.1          # via wagtail
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.8           # via requests
-wagtail==2.3              # via -r requirements/base.in
+wagtail==2.6.2            # via -r requirements/base.in
 webencodings==0.5.1       # via html5lib
 willow==1.1               # via wagtail
 zipp==1.2.0               # via -r requirements/base.in, importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -29,7 +29,7 @@ django-extensions==2.2.8  # via -r requirements/quality.txt
 django-modelcluster==4.4.1  # via -r requirements/quality.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt
 django-storages==1.9.1    # via -r requirements/quality.txt
-django-taggit==0.23.0     # via -r requirements/quality.txt, wagtail
+django-taggit==0.24.0     # via -r requirements/quality.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/quality.txt, wagtail
 django-waffle==0.20.0     # via -r requirements/quality.txt, edx-django-utils, edx-drf-extensions
 django==1.11.29           # via -r requirements/quality.txt, code-annotations, django-cors-headers, django-debug-toolbar, django-storages, django-taggit, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, wagtail
@@ -71,7 +71,7 @@ path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
 pbr==5.4.4                # via -r requirements/quality.txt, stevedore
-pillow==5.4.1             # via -r requirements/quality.txt, wagtail
+pillow==6.2.2             # via -r requirements/quality.txt, wagtail
 pip-tools==4.5.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
@@ -82,7 +82,7 @@ pycryptodomex==3.9.7      # via -r requirements/quality.txt, pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.txt
 pygments==2.6.1           # via diff-cover
 pyjwkest==1.4.2           # via -r requirements/quality.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/quality.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt==1.7.1              # via -r requirements/quality.txt, djangorestframework-jwt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
 pylint-django==0.7.2      # via -r requirements/quality.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
@@ -107,7 +107,7 @@ slumber==0.7.1            # via -r requirements/quality.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/quality.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/quality.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.3.1           # via django-debug-toolbar
+sqlparse==0.3.1           # via -r requirements/quality.txt, django, django-debug-toolbar
 stevedore==1.32.0         # via -r requirements/quality.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/quality.txt, faker, python-slugify
 toml==0.10.0              # via -r requirements/quality.txt, tox
@@ -116,7 +116,7 @@ unidecode==1.1.1          # via -r requirements/quality.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/quality.txt, coreapi
 urllib3==1.25.8           # via -r requirements/quality.txt, requests
 virtualenv==20.0.9        # via -r requirements/quality.txt, tox
-wagtail==2.3              # via -r requirements/quality.txt
+wagtail==2.6.2            # via -r requirements/quality.txt
 wcwidth==0.1.8            # via -r requirements/quality.txt, pytest
 webencodings==0.5.1       # via -r requirements/quality.txt, html5lib
 willow==1.1               # via -r requirements/quality.txt, wagtail

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-<<<<<<< 1.11.29           # via -r requirements/base.txt, django-cors-headers, django-storages, django-taggit, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+django==1.11.29           # via -r requirements/base.txt, django-cors-headers, django-storages, django-taggit, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==1.11.29           # via -r requirements/base.txt, django-cors-headers, django-storages, django-taggit, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+<<<<<<< 1.11.29           # via -r requirements/base.txt, django-cors-headers, django-storages, django-taggit, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -27,7 +27,7 @@ django-extensions==2.2.8  # via -r requirements/test.txt
 django-modelcluster==4.4.1  # via -r requirements/test.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-storages==1.9.1    # via -r requirements/test.txt
-django-taggit==0.23.0     # via -r requirements/test.txt, wagtail
+django-taggit==0.24.0     # via -r requirements/test.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/test.txt, wagtail
 django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django==1.11.29           # via -r requirements/test.txt, code-annotations, django-cors-headers, django-storages, django-taggit, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
@@ -69,14 +69,14 @@ openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.3           # via -r requirements/test.txt, pytest, sphinx, tox
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.4                # via -r requirements/test.txt, stevedore
-pillow==5.4.1             # via -r requirements/test.txt, wagtail
-pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
+pillow==6.2.2             # via -r requirements/test.txt, wagtail
+pluggy==0.13.1            # via -r requirements/test.txt, pytest
 psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
-py==1.8.1                 # via -r requirements/test.txt, pytest, tox
+py==1.8.1                 # via -r requirements/test.txt, pytest
 pycryptodomex==3.9.7      # via -r requirements/test.txt, pyjwkest
 pygments==2.6.1           # via readme-renderer, sphinx
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt==1.7.1              # via -r requirements/test.txt, djangorestframework-jwt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==0.7.2      # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
@@ -110,6 +110,7 @@ sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
+sqlparse==0.3.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, doc8, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.0              # via -r requirements/test.txt, tox
@@ -118,7 +119,7 @@ unidecode==1.1.1          # via -r requirements/test.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.8           # via -r requirements/test.txt, requests
 virtualenv==20.0.9        # via -r requirements/test.txt, tox
-wagtail==2.3              # via -r requirements/test.txt
+wagtail==2.6.2            # via -r requirements/test.txt
 wcwidth==0.1.8            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via -r requirements/test.txt, bleach, html5lib
 willow==1.1               # via -r requirements/test.txt, wagtail

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -17,7 +17,7 @@ django-extensions==2.2.8  # via -r requirements/base.txt
 django-modelcluster==4.4.1  # via -r requirements/base.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-storages==1.9.1    # via -r requirements/base.txt
-django-taggit==0.23.0     # via -r requirements/base.txt, wagtail
+django-taggit==0.24.0     # via -r requirements/base.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/base.txt, wagtail
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 django==1.11.29           # via -r requirements/base.txt, django-cors-headers, django-storages, django-taggit, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
@@ -49,11 +49,11 @@ newrelic==5.10.0.138      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.4                # via -r requirements/base.txt, stevedore
-pillow==5.4.1             # via -r requirements/base.txt, wagtail
+pillow==6.2.2             # via -r requirements/base.txt, wagtail
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
 pycryptodomex==3.9.7      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt==1.7.1              # via -r requirements/base.txt, djangorestframework-jwt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.0    # via -r requirements/base.txt, botocore, edx-drf-extensions
 python-memcached==1.59    # via -r requirements/production.in
@@ -70,11 +70,12 @@ six==1.14.0               # via -r requirements/base.txt, django-extensions, dja
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
 unidecode==1.1.1          # via -r requirements/base.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.8           # via -r requirements/base.txt, botocore, requests
-wagtail==2.3              # via -r requirements/base.txt
+wagtail==2.6.2            # via -r requirements/base.txt
 webencodings==0.5.1       # via -r requirements/base.txt, html5lib
 willow==1.1               # via -r requirements/base.txt, wagtail
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -27,7 +27,7 @@ django-extensions==2.2.8  # via -r requirements/test.txt
 django-modelcluster==4.4.1  # via -r requirements/test.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-storages==1.9.1    # via -r requirements/test.txt
-django-taggit==0.23.0     # via -r requirements/test.txt, wagtail
+django-taggit==0.24.0     # via -r requirements/test.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/test.txt, wagtail
 django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
 django==1.11.29           # via -r requirements/test.txt, code-annotations, django-cors-headers, django-storages, django-taggit, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
@@ -65,15 +65,15 @@ openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.3           # via -r requirements/test.txt, caniusepython3, pytest, tox
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.4                # via -r requirements/test.txt, stevedore
-pillow==5.4.1             # via -r requirements/test.txt, wagtail
-pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
+pillow==6.2.2             # via -r requirements/test.txt, wagtail
+pluggy==0.13.1            # via -r requirements/test.txt, pytest
 psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
-py==1.8.1                 # via -r requirements/test.txt, pytest, tox
+py==1.8.1                 # via -r requirements/test.txt, pytest
 pycodestyle==2.5.0        # via -r requirements/quality.in
 pycryptodomex==3.9.7      # via -r requirements/test.txt, pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt==1.7.1              # via -r requirements/test.txt, djangorestframework-jwt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==0.7.2      # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
@@ -98,6 +98,7 @@ slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.3.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.0              # via -r requirements/test.txt, tox
@@ -106,7 +107,7 @@ unidecode==1.1.1          # via -r requirements/test.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.8           # via -r requirements/test.txt, requests
 virtualenv==20.0.9        # via -r requirements/test.txt, tox
-wagtail==2.3              # via -r requirements/test.txt
+wagtail==2.6.2            # via -r requirements/test.txt
 wcwidth==0.1.8            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via -r requirements/test.txt, html5lib
 willow==1.1               # via -r requirements/test.txt, wagtail

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -24,7 +24,7 @@ django-extensions==2.2.8  # via -r requirements/base.txt
 django-modelcluster==4.4.1  # via -r requirements/base.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-storages==1.9.1    # via -r requirements/base.txt
-django-taggit==0.23.0     # via -r requirements/base.txt, wagtail
+django-taggit==0.24.0     # via -r requirements/base.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/base.txt, wagtail
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 djangorestframework==3.9.4  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
@@ -61,13 +61,13 @@ openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.3           # via pytest, tox
 pathlib2==2.3.5           # via pytest
 pbr==5.4.4                # via -r requirements/base.txt, stevedore
-pillow==5.4.1             # via -r requirements/base.txt, wagtail
-pluggy==0.13.1            # via pytest, tox
+pillow==6.2.2             # via -r requirements/base.txt, wagtail
+pluggy==0.13.1            # via pytest
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
-py==1.8.1                 # via pytest, tox
+py==1.8.1                 # via pytest
 pycryptodomex==3.9.7      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt==1.7.1              # via -r requirements/base.txt, djangorestframework-jwt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
 pylint-django==0.7.2      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
@@ -91,6 +91,7 @@ six==1.14.0               # via -r requirements/base.txt, astroid, django-dynami
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via faker, python-slugify
 toml==0.10.0              # via tox
@@ -99,7 +100,7 @@ unidecode==1.1.1          # via -r requirements/base.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.8           # via -r requirements/base.txt, requests
 virtualenv==20.0.9        # via tox
-wagtail==2.3              # via -r requirements/base.txt
+wagtail==2.6.2            # via -r requirements/base.txt
 wcwidth==0.1.8            # via pytest
 webencodings==0.5.1       # via -r requirements/base.txt, html5lib
 willow==1.1               # via -r requirements/base.txt, wagtail


### PR DESCRIPTION
**Issue:** [BOM-1323](https://openedx.atlassian.net/browse/BOM-1323)
### Description 
`wagtail` package was pinned bacause of `edx-drf-extensions`. Now updated to `2.6.2` after new release of `edx-drf-extensions==4.0.1` is out. 