### PR TITLE
BOM-1402 Dropped support for Django1.11

### DIFF
--- a/.annotation_safe_list.yml
+++ b/.annotation_safe_list.yml
@@ -73,3 +73,5 @@ wagtailsearch.QueryDailyHits:
   ".. no_pii:": "This model has no PII"
 wagtailusers.UserProfile:
     ".. no_pii:": "This model has no PII"
+blacklist.BlacklistedToken:
+    ".. no_pii:": "This model has no PII"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: python
 matrix:
   include:
     - python: 3.5
-      env: TOXENV=django111
-      script: make validate
-    - python: 3.5
       env: TOXENV=django20
       script: make validate
     - python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ matrix:
       env: TOXENV=django21
       script: make validate
     - python: 3.5
+      env: TOXENV=django22
+      script: make validate
+    - python: 3.5
       env: TESTNAME=quality
       script:
         - make quality

--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip-compile --upgrade -o requirements/dev.txt requirements/dev.in
 	pip-compile --upgrade -o requirements/production.txt requirements/production.in
 	# Let tox control the Django version for tests
+	grep -e "^django==" requirements/production.txt > requirements/django.txt
 	sed '/^[dD]jango==/d' requirements/test.txt > requirements/test.tmp
 	mv requirements/test.tmp requirements/test.txt
 

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,6 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip-compile --upgrade -o requirements/dev.txt requirements/dev.in
 	pip-compile --upgrade -o requirements/production.txt requirements/production.in
 	# Let tox control the Django version for tests
-	grep -e "^django==" requirements/production.txt > requirements/django.txt
 	sed '/^[dD]jango==/d' requirements/test.txt > requirements/test.tmp
 	mv requirements/test.tmp requirements/test.txt
 

--- a/designer/settings/base.py
+++ b/designer/settings/base.py
@@ -36,6 +36,8 @@ THIRD_PARTY_APPS = (
     'waffle',
     'modelcluster',
     'taggit',
+    'rest_framework_jwt',
+    'rest_framework_jwt.blacklist',
 )
 
 PROJECT_APPS = (
@@ -217,7 +219,8 @@ JWT_AUTH = {
     'JWT_PUBLIC_SIGNING_JWK_SET': None,
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
-    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie'
+    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie',
+    'JWT_AUTH_HEADER_PREFIX': 'JWT',
 }
 
 # Request the user's permissions in the ID token

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -13,7 +13,7 @@ edx-auth-backends
 edx-django-release-util
 edx-django-utils
 edx-drf-extensions
-edx_rest_api_client
+edx_rest_api_client==4.0.1      # versions>4.0.1 have backward incompatible changes in timeout handling
 mysqlclient
 pytz
 python-dateutil==2.8.0    # botocore has a <2.8.1 constraint. This is not a direct dependency and can be deleted (vs unpinned) when no longer needed

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,7 +2,7 @@
 
 -r github.in              # Forks and other dependencies not yet on PyPI
 
-Django>=1.8,<2.0          # Web application framework
+Django>=2.0,<3.0          # Web application framework
 django-cors-headers
 django-extensions
 django-rest-swagger
@@ -17,7 +17,7 @@ edx_rest_api_client
 mysqlclient
 pytz
 python-dateutil==2.8.0    # botocore has a <2.8.1 constraint. This is not a direct dependency and can be deleted (vs unpinned) when no longer needed
-wagtail==2.3     # wagtail>2.3 dropped support for django111
+wagtail<2.8      # wagtail>=2.8 dropped support for Django 2.0
 zipp==1.2.0      # greater versions dropped Python 3.5 support
 mock<4.0.0      # mock>=4.0.0 dropped support for python3.5
 inflect<4.0.0   # inflect>=4.0.0 dropped support for python3.5

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,7 +25,7 @@ drf-jwt==1.15.1           # via edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.in
 edx-django-release-util==0.3.6  # via -r requirements/base.in
 edx-django-utils==3.0     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==4.0.2  # via -r requirements/base.in
+edx-drf-extensions==4.0.3  # via -r requirements/base.in
 edx-opaque-keys==2.0.1    # via edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -r requirements/base.in
 future==0.18.2            # via pyjwkest

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -21,13 +21,13 @@ django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-d
 django==2.2.11            # via -r requirements/base.in, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via wagtail
-drf-jwt==1.15.0           # via edx-drf-extensions
+drf-jwt==1.15.1           # via edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.in
 edx-django-release-util==0.3.6  # via -r requirements/base.in
 edx-django-utils==3.0     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==4.0.2  # via -r requirements/base.in
 edx-opaque-keys==2.0.1    # via edx-drf-extensions
-edx-rest-api-client==5.0.1  # via -r requirements/base.in
+edx_rest_api_client==4.0.1  # via -r requirements/base.in
 future==0.18.2            # via pyjwkest
 html5lib==1.0.1           # via wagtail
 idna==2.9                 # via requests

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -12,22 +12,22 @@ coreschema==0.0.4         # via coreapi
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-cors-headers==3.2.1  # via -r requirements/base.in
 django-extensions==2.2.8  # via -r requirements/base.in
-django-modelcluster==4.4.1  # via wagtail
+django-modelcluster==5.0.1  # via wagtail
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-storages==1.9.1    # via -r requirements/base.in
-django-taggit==0.23.0     # via wagtail
+django-taggit==1.2.0      # via wagtail
 django-treebeard==4.3.1   # via wagtail
 django-waffle==0.20.0     # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
-django==1.11.29           # via -r requirements/base.in, django-cors-headers, django-storages, django-taggit, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
-djangorestframework==3.9.4  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
+django==2.2.11            # via -r requirements/base.in, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via wagtail
 drf-jwt==1.15.0           # via edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.in
 edx-django-release-util==0.3.6  # via -r requirements/base.in
 edx-django-utils==3.0     # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==4.0.1  # via -r requirements/base.in
+edx-drf-extensions==4.0.2  # via -r requirements/base.in
 edx-opaque-keys==2.0.1    # via edx-drf-extensions
-edx-rest-api-client==4.0.1  # via -r requirements/base.in
+edx-rest-api-client==5.0.1  # via -r requirements/base.in
 future==0.18.2            # via pyjwkest
 html5lib==1.0.1           # via wagtail
 idna==2.9                 # via requests
@@ -42,7 +42,7 @@ newrelic==5.10.0.138      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.4                # via stevedore
-pillow==5.4.1             # via wagtail
+pillow==6.2.2             # via wagtail
 psutil==1.2.1             # via edx-django-utils
 pycryptodomex==3.9.7      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
@@ -61,11 +61,12 @@ six==1.14.0               # via django-extensions, django-waffle, edx-auth-backe
 slumber==0.7.1            # via edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, edx-auth-backends
 social-auth-core==3.2.0   # via edx-auth-backends, social-auth-app-django
+sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
 unidecode==1.1.1          # via wagtail
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.8           # via requests
-wagtail==2.3              # via -r requirements/base.in
+wagtail==2.7.1            # via -r requirements/base.in
 webencodings==0.5.1       # via html5lib
-willow==1.1               # via wagtail
+willow==1.3               # via wagtail
 zipp==1.2.0               # via -r requirements/base.in, importlib-metadata

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -35,7 +35,7 @@ django-waffle==0.20.0     # via -r requirements/quality.txt, edx-django-utils, e
 django==2.2.11            # via -r requirements/quality.txt, code-annotations, django-cors-headers, django-debug-toolbar, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, wagtail
 djangorestframework==3.11.0  # via -r requirements/quality.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/quality.txt, wagtail
-drf-jwt==1.15.0           # via -r requirements/quality.txt, edx-drf-extensions
+drf-jwt==1.15.1           # via -r requirements/quality.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/quality.txt
 edx-django-release-util==0.3.6  # via -r requirements/quality.txt
 edx-django-utils==3.0     # via -r requirements/quality.txt, edx-drf-extensions, edx-rest-api-client
@@ -43,7 +43,7 @@ edx-drf-extensions==4.0.2  # via -r requirements/quality.txt
 edx-i18n-tools==0.5.0     # via -r requirements/dev.in
 edx-lint==1.3.0           # via -r requirements/quality.txt
 edx-opaque-keys==2.0.1    # via -r requirements/quality.txt, edx-drf-extensions
-edx-rest-api-client==5.0.1  # via -r requirements/quality.txt
+edx_rest_api_client==4.0.1  # via -r requirements/quality.txt
 factory-boy==2.12.0       # via -r requirements/quality.txt
 faker==4.0.1              # via -r requirements/quality.txt, factory-boy
 filelock==3.0.12          # via -r requirements/quality.txt, tox, virtualenv
@@ -91,7 +91,7 @@ pymongo==3.10.1           # via -r requirements/quality.txt, edx-opaque-keys
 pyparsing==2.4.6          # via -r requirements/quality.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/quality.txt
 pytest-django==3.8.0      # via -r requirements/quality.txt
-pytest==5.3.5             # via -r requirements/quality.txt, pytest-cov, pytest-django
+pytest==5.4.0             # via -r requirements/quality.txt, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via -r requirements/quality.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/quality.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/quality.txt, social-auth-core

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -26,24 +26,24 @@ django-cors-headers==3.2.1  # via -r requirements/quality.txt
 django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-dynamic-fixture==3.0.3  # via -r requirements/quality.txt
 django-extensions==2.2.8  # via -r requirements/quality.txt
-django-modelcluster==4.4.1  # via -r requirements/quality.txt, wagtail
+django-modelcluster==5.0.1  # via -r requirements/quality.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt
 django-storages==1.9.1    # via -r requirements/quality.txt
-django-taggit==0.23.0     # via -r requirements/quality.txt, wagtail
+django-taggit==1.2.0      # via -r requirements/quality.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/quality.txt, wagtail
 django-waffle==0.20.0     # via -r requirements/quality.txt, edx-django-utils, edx-drf-extensions
-django==1.11.29           # via -r requirements/quality.txt, code-annotations, django-cors-headers, django-debug-toolbar, django-storages, django-taggit, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, wagtail
-djangorestframework==3.9.4  # via -r requirements/quality.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
+django==2.2.11            # via -r requirements/quality.txt, code-annotations, django-cors-headers, django-debug-toolbar, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, wagtail
+djangorestframework==3.11.0  # via -r requirements/quality.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/quality.txt, wagtail
 drf-jwt==1.15.0           # via -r requirements/quality.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/quality.txt
 edx-django-release-util==0.3.6  # via -r requirements/quality.txt
 edx-django-utils==3.0     # via -r requirements/quality.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==4.0.1  # via -r requirements/quality.txt
+edx-drf-extensions==4.0.2  # via -r requirements/quality.txt
 edx-i18n-tools==0.5.0     # via -r requirements/dev.in
 edx-lint==1.3.0           # via -r requirements/quality.txt
 edx-opaque-keys==2.0.1    # via -r requirements/quality.txt, edx-drf-extensions
-edx-rest-api-client==4.0.1  # via -r requirements/quality.txt
+edx-rest-api-client==5.0.1  # via -r requirements/quality.txt
 factory-boy==2.12.0       # via -r requirements/quality.txt
 faker==4.0.1              # via -r requirements/quality.txt, factory-boy
 filelock==3.0.12          # via -r requirements/quality.txt, tox, virtualenv
@@ -71,7 +71,7 @@ path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
 pbr==5.4.4                # via -r requirements/quality.txt, stevedore
-pillow==5.4.1             # via -r requirements/quality.txt, wagtail
+pillow==6.2.2             # via -r requirements/quality.txt, wagtail
 pip-tools==4.5.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
@@ -107,7 +107,7 @@ slumber==0.7.1            # via -r requirements/quality.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/quality.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/quality.txt, edx-auth-backends, social-auth-app-django
-sqlparse==0.3.1           # via django-debug-toolbar
+sqlparse==0.3.1           # via -r requirements/quality.txt, django, django-debug-toolbar
 stevedore==1.32.0         # via -r requirements/quality.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/quality.txt, faker, python-slugify
 toml==0.10.0              # via -r requirements/quality.txt, tox
@@ -115,11 +115,11 @@ tox==3.14.5               # via -r requirements/quality.txt
 unidecode==1.1.1          # via -r requirements/quality.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/quality.txt, coreapi
 urllib3==1.25.8           # via -r requirements/quality.txt, requests
-virtualenv==20.0.9        # via -r requirements/quality.txt, tox
-wagtail==2.3              # via -r requirements/quality.txt
+virtualenv==20.0.10       # via -r requirements/quality.txt, tox
+wagtail==2.7.1            # via -r requirements/quality.txt
 wcwidth==0.1.8            # via -r requirements/quality.txt, pytest
 webencodings==0.5.1       # via -r requirements/quality.txt, html5lib
-willow==1.1               # via -r requirements/quality.txt, wagtail
+willow==1.3               # via -r requirements/quality.txt, wagtail
 wrapt==1.12.1             # via -r requirements/quality.txt, astroid
 zipp==1.2.0               # via -r requirements/quality.txt, importlib-metadata, importlib-resources
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -39,13 +39,13 @@ drf-jwt==1.15.1           # via -r requirements/quality.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/quality.txt
 edx-django-release-util==0.3.6  # via -r requirements/quality.txt
 edx-django-utils==3.0     # via -r requirements/quality.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==4.0.2  # via -r requirements/quality.txt
+edx-drf-extensions==4.0.3  # via -r requirements/quality.txt
 edx-i18n-tools==0.5.0     # via -r requirements/dev.in
 edx-lint==1.3.0           # via -r requirements/quality.txt
 edx-opaque-keys==2.0.1    # via -r requirements/quality.txt, edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -r requirements/quality.txt
 factory-boy==2.12.0       # via -r requirements/quality.txt
-faker==4.0.1              # via -r requirements/quality.txt, factory-boy
+faker==4.0.2              # via -r requirements/quality.txt, factory-boy
 filelock==3.0.12          # via -r requirements/quality.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/quality.txt, pyjwkest
 html5lib==1.0.1           # via -r requirements/quality.txt, wagtail
@@ -91,7 +91,7 @@ pymongo==3.10.1           # via -r requirements/quality.txt, edx-opaque-keys
 pyparsing==2.4.6          # via -r requirements/quality.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/quality.txt
 pytest-django==3.8.0      # via -r requirements/quality.txt
-pytest==5.4.0             # via -r requirements/quality.txt, pytest-cov, pytest-django
+pytest==5.4.1             # via -r requirements/quality.txt, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via -r requirements/quality.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/quality.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/quality.txt, social-auth-core

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==1.11.29           # via -r requirements/base.txt, django-cors-headers, django-storages, django-taggit, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+django==2.2.11            # via -r requirements/base.txt, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -24,14 +24,14 @@ distlib==0.3.0            # via -r requirements/test.txt, virtualenv
 django-cors-headers==3.2.1  # via -r requirements/test.txt
 django-dynamic-fixture==3.0.3  # via -r requirements/test.txt
 django-extensions==2.2.8  # via -r requirements/test.txt
-django-modelcluster==4.4.1  # via -r requirements/test.txt, wagtail
+django-modelcluster==5.0.1  # via -r requirements/test.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-storages==1.9.1    # via -r requirements/test.txt
-django-taggit==0.23.0     # via -r requirements/test.txt, wagtail
+django-taggit==1.2.0      # via -r requirements/test.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/test.txt, wagtail
 django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==1.11.29           # via -r requirements/test.txt, code-annotations, django-cors-headers, django-storages, django-taggit, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
-djangorestframework==3.9.4  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
+django==2.2.11            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 doc8==0.8.0               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 draftjs-exporter==2.1.7   # via -r requirements/test.txt, wagtail
@@ -39,10 +39,10 @@ drf-jwt==1.15.0           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/test.txt
 edx-django-release-util==0.3.6  # via -r requirements/test.txt
 edx-django-utils==3.0     # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==4.0.1  # via -r requirements/test.txt
+edx-drf-extensions==4.0.2  # via -r requirements/test.txt
 edx-lint==1.3.0           # via -r requirements/test.txt
 edx-opaque-keys==2.0.1    # via -r requirements/test.txt, edx-drf-extensions
-edx-rest-api-client==4.0.1  # via -r requirements/test.txt
+edx-rest-api-client==5.0.1  # via -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.0.1              # via -r requirements/test.txt, factory-boy
@@ -69,7 +69,7 @@ openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.3           # via -r requirements/test.txt, pytest, sphinx, tox
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.4                # via -r requirements/test.txt, stevedore
-pillow==5.4.1             # via -r requirements/test.txt, wagtail
+pillow==6.2.2             # via -r requirements/test.txt, wagtail
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
 py==1.8.1                 # via -r requirements/test.txt, pytest, tox
@@ -110,6 +110,7 @@ sphinxcontrib-htmlhelp==1.0.3  # via sphinx
 sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
+sqlparse==0.3.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, doc8, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.0              # via -r requirements/test.txt, tox
@@ -117,11 +118,11 @@ tox==3.14.5               # via -r requirements/test.txt
 unidecode==1.1.1          # via -r requirements/test.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.8           # via -r requirements/test.txt, requests
-virtualenv==20.0.9        # via -r requirements/test.txt, tox
-wagtail==2.3              # via -r requirements/test.txt
+virtualenv==20.0.10       # via -r requirements/test.txt, tox
+wagtail==2.7.1            # via -r requirements/test.txt
 wcwidth==0.1.8            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via -r requirements/test.txt, bleach, html5lib
-willow==1.1               # via -r requirements/test.txt, wagtail
+willow==1.3               # via -r requirements/test.txt, wagtail
 wrapt==1.12.1             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources
 

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -35,15 +35,15 @@ djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger
 doc8==0.8.0               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 draftjs-exporter==2.1.7   # via -r requirements/test.txt, wagtail
-drf-jwt==1.15.0           # via -r requirements/test.txt, edx-drf-extensions
+drf-jwt==1.15.1           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/test.txt
 edx-django-release-util==0.3.6  # via -r requirements/test.txt
 edx-django-utils==3.0     # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==4.0.2  # via -r requirements/test.txt
 edx-lint==1.3.0           # via -r requirements/test.txt
 edx-opaque-keys==2.0.1    # via -r requirements/test.txt, edx-drf-extensions
-edx-rest-api-client==5.0.1  # via -r requirements/test.txt
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
+edx_rest_api_client==4.0.1  # via -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.0.1              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
@@ -85,7 +85,7 @@ pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.6          # via -r requirements/test.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.8.0      # via -r requirements/test.txt
-pytest==5.3.5             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.0             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -39,13 +39,13 @@ drf-jwt==1.15.1           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/test.txt
 edx-django-release-util==0.3.6  # via -r requirements/test.txt
 edx-django-utils==3.0     # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==4.0.2  # via -r requirements/test.txt
+edx-drf-extensions==4.0.3  # via -r requirements/test.txt
 edx-lint==1.3.0           # via -r requirements/test.txt
 edx-opaque-keys==2.0.1    # via -r requirements/test.txt, edx-drf-extensions
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 edx_rest_api_client==4.0.1  # via -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
-faker==4.0.1              # via -r requirements/test.txt, factory-boy
+faker==4.0.2              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 html5lib==1.0.1           # via -r requirements/test.txt, wagtail
@@ -85,13 +85,13 @@ pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.6          # via -r requirements/test.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.8.0      # via -r requirements/test.txt
-pytest==5.4.0             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core
 pytz==2019.3              # via -r requirements/test.txt, babel, django, django-modelcluster, wagtail
 pyyaml==5.3               # via -r requirements/test.txt, code-annotations, edx-django-release-util
-readme-renderer==24.0     # via -r requirements/doc.in
+readme-renderer==25.0     # via -r requirements/doc.in
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests==2.23.0          # via -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx, wagtail
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,8 +5,8 @@
 #    make upgrade
 #
 beautifulsoup4==4.6.0     # via -r requirements/base.txt, wagtail
-boto3==1.12.17            # via -r requirements/production.in
-botocore==1.15.17         # via boto3, s3transfer
+boto3==1.12.19            # via -r requirements/production.in
+botocore==1.15.19         # via boto3, s3transfer
 certifi==2019.11.28       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
@@ -14,23 +14,23 @@ coreschema==0.0.4         # via -r requirements/base.txt, coreapi
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.2.1  # via -r requirements/base.txt
 django-extensions==2.2.8  # via -r requirements/base.txt
-django-modelcluster==4.4.1  # via -r requirements/base.txt, wagtail
+django-modelcluster==5.0.1  # via -r requirements/base.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-storages==1.9.1    # via -r requirements/base.txt
-django-taggit==0.23.0     # via -r requirements/base.txt, wagtail
+django-taggit==1.2.0      # via -r requirements/base.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/base.txt, wagtail
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==1.11.29           # via -r requirements/base.txt, django-cors-headers, django-storages, django-taggit, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
-djangorestframework==3.9.4  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
+django==2.2.11            # via -r requirements/base.txt, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 docutils==0.15.2          # via botocore
 draftjs-exporter==2.1.7   # via -r requirements/base.txt, wagtail
 drf-jwt==1.15.0           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.3.6  # via -r requirements/base.txt
 edx-django-utils==3.0     # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==4.0.1  # via -r requirements/base.txt
+edx-drf-extensions==4.0.2  # via -r requirements/base.txt
 edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-drf-extensions
-edx-rest-api-client==4.0.1  # via -r requirements/base.txt
+edx-rest-api-client==5.0.1  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 gevent==1.4.0             # via -r requirements/production.in
 greenlet==0.4.15          # via gevent
@@ -49,7 +49,7 @@ newrelic==5.10.0.138      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.4                # via -r requirements/base.txt, stevedore
-pillow==5.4.1             # via -r requirements/base.txt, wagtail
+pillow==6.2.2             # via -r requirements/base.txt, wagtail
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
 pycryptodomex==3.9.7      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
@@ -70,13 +70,14 @@ six==1.14.0               # via -r requirements/base.txt, django-extensions, dja
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
 unidecode==1.1.1          # via -r requirements/base.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.8           # via -r requirements/base.txt, botocore, requests
-wagtail==2.3              # via -r requirements/base.txt
+wagtail==2.7.1            # via -r requirements/base.txt
 webencodings==0.5.1       # via -r requirements/base.txt, html5lib
-willow==1.1               # via -r requirements/base.txt, wagtail
+willow==1.3               # via -r requirements/base.txt, wagtail
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,8 +5,8 @@
 #    make upgrade
 #
 beautifulsoup4==4.6.0     # via -r requirements/base.txt, wagtail
-boto3==1.12.19            # via -r requirements/production.in
-botocore==1.15.19         # via boto3, s3transfer
+boto3==1.12.20            # via -r requirements/production.in
+botocore==1.15.20         # via boto3, s3transfer
 certifi==2019.11.28       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
@@ -24,13 +24,13 @@ django==2.2.11            # via -r requirements/base.txt, django-cors-headers, d
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 docutils==0.15.2          # via botocore
 draftjs-exporter==2.1.7   # via -r requirements/base.txt, wagtail
-drf-jwt==1.15.0           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.15.1           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.3.6  # via -r requirements/base.txt
 edx-django-utils==3.0     # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==4.0.2  # via -r requirements/base.txt
 edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-drf-extensions
-edx-rest-api-client==5.0.1  # via -r requirements/base.txt
+edx_rest_api_client==4.0.1  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 gevent==1.4.0             # via -r requirements/production.in
 greenlet==0.4.15          # via gevent

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,8 +5,8 @@
 #    make upgrade
 #
 beautifulsoup4==4.6.0     # via -r requirements/base.txt, wagtail
-boto3==1.12.20            # via -r requirements/production.in
-botocore==1.15.20         # via boto3, s3transfer
+boto3==1.12.21            # via -r requirements/production.in
+botocore==1.15.21         # via boto3, s3transfer
 certifi==2019.11.28       # via -r requirements/base.txt, requests
 chardet==3.0.4            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
@@ -28,7 +28,7 @@ drf-jwt==1.15.1           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.3.6  # via -r requirements/base.txt
 edx-django-utils==3.0     # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==4.0.2  # via -r requirements/base.txt
+edx-drf-extensions==4.0.3  # via -r requirements/base.txt
 edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, pyjwkest

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -33,14 +33,14 @@ django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-
 django==2.2.11            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
 djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/test.txt, wagtail
-drf-jwt==1.15.0           # via -r requirements/test.txt, edx-drf-extensions
+drf-jwt==1.15.1           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/test.txt
 edx-django-release-util==0.3.6  # via -r requirements/test.txt
 edx-django-utils==3.0     # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==4.0.2  # via -r requirements/test.txt
 edx-lint==1.3.0           # via -r requirements/quality.in, -r requirements/test.txt
 edx-opaque-keys==2.0.1    # via -r requirements/test.txt, edx-drf-extensions
-edx-rest-api-client==5.0.1  # via -r requirements/test.txt
+edx_rest_api_client==4.0.1  # via -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.0.1              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
@@ -82,7 +82,7 @@ pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.6          # via -r requirements/test.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.8.0      # via -r requirements/test.txt
-pytest==5.3.5             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.0             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -24,23 +24,23 @@ distlib==0.3.0            # via -r requirements/test.txt, caniusepython3, virtua
 django-cors-headers==3.2.1  # via -r requirements/test.txt
 django-dynamic-fixture==3.0.3  # via -r requirements/test.txt
 django-extensions==2.2.8  # via -r requirements/test.txt
-django-modelcluster==4.4.1  # via -r requirements/test.txt, wagtail
+django-modelcluster==5.0.1  # via -r requirements/test.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-storages==1.9.1    # via -r requirements/test.txt
-django-taggit==0.23.0     # via -r requirements/test.txt, wagtail
+django-taggit==1.2.0      # via -r requirements/test.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/test.txt, wagtail
 django-waffle==0.20.0     # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==1.11.29           # via -r requirements/test.txt, code-annotations, django-cors-headers, django-storages, django-taggit, django-treebeard, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
-djangorestframework==3.9.4  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
+django==2.2.11            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/test.txt, wagtail
 drf-jwt==1.15.0           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/test.txt
 edx-django-release-util==0.3.6  # via -r requirements/test.txt
 edx-django-utils==3.0     # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==4.0.1  # via -r requirements/test.txt
+edx-drf-extensions==4.0.2  # via -r requirements/test.txt
 edx-lint==1.3.0           # via -r requirements/quality.in, -r requirements/test.txt
 edx-opaque-keys==2.0.1    # via -r requirements/test.txt, edx-drf-extensions
-edx-rest-api-client==4.0.1  # via -r requirements/test.txt
+edx-rest-api-client==5.0.1  # via -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.0.1              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
@@ -65,7 +65,7 @@ openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.3           # via -r requirements/test.txt, caniusepython3, pytest, tox
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.4                # via -r requirements/test.txt, stevedore
-pillow==5.4.1             # via -r requirements/test.txt, wagtail
+pillow==6.2.2             # via -r requirements/test.txt, wagtail
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
 py==1.8.1                 # via -r requirements/test.txt, pytest, tox
@@ -98,6 +98,7 @@ slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.3.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.0              # via -r requirements/test.txt, tox
@@ -105,11 +106,11 @@ tox==3.14.5               # via -r requirements/test.txt
 unidecode==1.1.1          # via -r requirements/test.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.8           # via -r requirements/test.txt, requests
-virtualenv==20.0.9        # via -r requirements/test.txt, tox
-wagtail==2.3              # via -r requirements/test.txt
+virtualenv==20.0.10       # via -r requirements/test.txt, tox
+wagtail==2.7.1            # via -r requirements/test.txt
 wcwidth==0.1.8            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via -r requirements/test.txt, html5lib
-willow==1.1               # via -r requirements/test.txt, wagtail
+willow==1.3               # via -r requirements/test.txt, wagtail
 wrapt==1.12.1             # via -r requirements/test.txt, astroid
 zipp==1.2.0               # via -r requirements/test.txt, importlib-metadata, importlib-resources
 

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -37,12 +37,12 @@ drf-jwt==1.15.1           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/test.txt
 edx-django-release-util==0.3.6  # via -r requirements/test.txt
 edx-django-utils==3.0     # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==4.0.2  # via -r requirements/test.txt
+edx-drf-extensions==4.0.3  # via -r requirements/test.txt
 edx-lint==1.3.0           # via -r requirements/quality.in, -r requirements/test.txt
 edx-opaque-keys==2.0.1    # via -r requirements/test.txt, edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
-faker==4.0.1              # via -r requirements/test.txt, factory-boy
+faker==4.0.2              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 html5lib==1.0.1           # via -r requirements/test.txt, wagtail
@@ -82,7 +82,7 @@ pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.6          # via -r requirements/test.txt, packaging
 pytest-cov==2.8.1         # via -r requirements/test.txt
 pytest-django==3.8.0      # via -r requirements/test.txt
-pytest==5.4.0             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest==5.4.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
 python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -21,22 +21,22 @@ distlib==0.3.0            # via virtualenv
 django-cors-headers==3.2.1  # via -r requirements/base.txt
 django-dynamic-fixture==3.0.3  # via -r requirements/test.in
 django-extensions==2.2.8  # via -r requirements/base.txt
-django-modelcluster==4.4.1  # via -r requirements/base.txt, wagtail
+django-modelcluster==5.0.1  # via -r requirements/base.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-storages==1.9.1    # via -r requirements/base.txt
-django-taggit==0.23.0     # via -r requirements/base.txt, wagtail
+django-taggit==1.2.0      # via -r requirements/base.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/base.txt, wagtail
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-djangorestframework==3.9.4  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
+djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/base.txt, wagtail
 drf-jwt==1.15.0           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.3.6  # via -r requirements/base.txt
 edx-django-utils==3.0     # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==4.0.1  # via -r requirements/base.txt
+edx-drf-extensions==4.0.2  # via -r requirements/base.txt
 edx-lint==1.3.0           # via -r requirements/test.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-drf-extensions
-edx-rest-api-client==4.0.1  # via -r requirements/base.txt
+edx-rest-api-client==5.0.1  # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.0.1              # via -r requirements/test.in, factory-boy
 filelock==3.0.12          # via tox, virtualenv
@@ -61,7 +61,7 @@ openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.3           # via pytest, tox
 pathlib2==2.3.5           # via pytest
 pbr==5.4.4                # via -r requirements/base.txt, stevedore
-pillow==5.4.1             # via -r requirements/base.txt, wagtail
+pillow==6.2.2             # via -r requirements/base.txt, wagtail
 pluggy==0.13.1            # via pytest, tox
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
 py==1.8.1                 # via pytest, tox
@@ -91,6 +91,7 @@ six==1.14.0               # via -r requirements/base.txt, astroid, django-dynami
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via faker, python-slugify
 toml==0.10.0              # via tox
@@ -98,10 +99,10 @@ tox==3.14.5               # via -r requirements/test.in
 unidecode==1.1.1          # via -r requirements/base.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.8           # via -r requirements/base.txt, requests
-virtualenv==20.0.9        # via tox
-wagtail==2.3              # via -r requirements/base.txt
+virtualenv==20.0.10       # via tox
+wagtail==2.7.1            # via -r requirements/base.txt
 wcwidth==0.1.8            # via pytest
 webencodings==0.5.1       # via -r requirements/base.txt, html5lib
-willow==1.1               # via -r requirements/base.txt, wagtail
+willow==1.3               # via -r requirements/base.txt, wagtail
 wrapt==1.12.1             # via astroid
 zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -33,12 +33,12 @@ drf-jwt==1.15.1           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.3.6  # via -r requirements/base.txt
 edx-django-utils==3.0     # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==4.0.2  # via -r requirements/base.txt
+edx-drf-extensions==4.0.3  # via -r requirements/base.txt
 edx-lint==1.3.0           # via -r requirements/test.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
-faker==4.0.1              # via -r requirements/test.in, factory-boy
+faker==4.0.2              # via -r requirements/test.in, factory-boy
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 html5lib==1.0.1           # via -r requirements/base.txt, wagtail
@@ -76,7 +76,7 @@ pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.8.0      # via -r requirements/test.in
-pytest==5.4.0             # via -r requirements/test.in, pytest-cov, pytest-django
+pytest==5.4.1             # via -r requirements/test.in, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via -r requirements/base.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via code-annotations
 python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -29,14 +29,14 @@ django-treebeard==4.3.1   # via -r requirements/base.txt, wagtail
 django-waffle==0.20.0     # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/base.txt, wagtail
-drf-jwt==1.15.0           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.15.1           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.0.2  # via -r requirements/base.txt
 edx-django-release-util==0.3.6  # via -r requirements/base.txt
 edx-django-utils==3.0     # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==4.0.2  # via -r requirements/base.txt
 edx-lint==1.3.0           # via -r requirements/test.in
 edx-opaque-keys==2.0.1    # via -r requirements/base.txt, edx-drf-extensions
-edx-rest-api-client==5.0.1  # via -r requirements/base.txt
+edx_rest_api_client==4.0.1  # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.0.1              # via -r requirements/test.in, factory-boy
 filelock==3.0.12          # via tox, virtualenv
@@ -76,7 +76,7 @@ pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1         # via -r requirements/test.in
 pytest-django==3.8.0      # via -r requirements/test.in
-pytest==5.3.5             # via -r requirements/test.in, pytest-cov, pytest-django
+pytest==5.4.0             # via -r requirements/test.in, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via -r requirements/base.txt, edx-drf-extensions, faker
 python-slugify==4.0.0     # via code-annotations
 python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py35}-django{111,20,21,22}
+envlist = {py35}-django{20,21,22}
 skipsdist = true
 
 [pytest]
@@ -8,7 +8,6 @@ testpaths = designer/apps
 
 [testenv]
 deps =
-    django111: -r requirements/django.txt
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
     django22: Django>=2.2,<2.3

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ testpaths = designer/apps
 deps =
     django20: Django>=2.0,<2.1
     django21: Django>=2.1,<2.2
-    django22: Django>=2.2,<2.3
+    django22:  -r requirements/django.txt
     -r {toxinidir}/requirements/test.txt
 commands =
     {posargs:python -Wd -m pytest}


### PR DESCRIPTION
**Ticket:** [BOM-1402](https://openedx.atlassian.net/browse/BOM-1402)

- Dropped support for Django1.11
- Added test support for Django2.2 in Travis
- Upgraded `wagtail` to 2.7.1