### PR TITLE
Update portal-designer requirements

### DIFF
--- a/designer/apps/core/apps.py
+++ b/designer/apps/core/apps.py
@@ -7,4 +7,4 @@ class CoreConfig(AppConfig):
     name = 'designer.apps.core'
 
     def ready(self):
-        from . import signals  # pylint: disable=unused-import
+        from . import signals  # pylint: disable=unused-import, import-outside-toplevel

--- a/designer/urls.py
+++ b/designer/urls.py
@@ -48,5 +48,5 @@ urlpatterns = oauth2_urlpatterns + [
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma: no cover
-    import debug_toolbar  # pylint: disable=import-error
+    import debug_toolbar
     urlpatterns.append(url(r'^__debug__/', include(debug_toolbar.urls)))

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -1,8 +1,9 @@
 # Core requirements for using this application
 
+-c constraints.txt
 -r github.in              # Forks and other dependencies not yet on PyPI
 
-Django>=2.0,<3.0          # Web application framework
+Django                    # Web application framework
 django-cors-headers
 django-extensions
 django-rest-swagger
@@ -13,12 +14,12 @@ edx-auth-backends
 edx-django-release-util
 edx-django-utils
 edx-drf-extensions
-edx_rest_api_client==4.0.1      # versions>4.0.1 have backward incompatible changes in timeout handling
+edx_rest_api_client
 mysqlclient
 pytz
-python-dateutil==2.8.0    # botocore has a <2.8.1 constraint. This is not a direct dependency and can be deleted (vs unpinned) when no longer needed
+python-dateutil
 wagtail
-zipp==1.2.0      # greater versions dropped Python 3.5 support
-mock<4.0.0      # mock>=4.0.0 dropped support for python3.5
-inflect<4.0.0   # inflect>=4.0.0 dropped support for python3.5
-social-auth-core==3.2.0    # version 3.3.0 causes problems in managing fields in admin view. Can be removed once {ARCHBOM-1078} is resolved.
+zipp
+mock
+inflect
+social-auth-core

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,59 +6,62 @@
 #
 beautifulsoup4==4.8.2     # via wagtail
 certifi==2020.6.20        # via requests
+cffi==1.14.0              # via cryptography
 chardet==3.0.4            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
+cryptography==2.9.2       # via pyjwt
 defusedxml==0.6.0         # via python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/base.in
-django-extensions==2.2.9  # via -r requirements/base.in
+django-extensions==3.0.3  # via -r requirements/base.in
 django-modelcluster==5.0.2  # via wagtail
 django-rest-swagger==2.2.0  # via -r requirements/base.in
 django-storages==1.9.1    # via -r requirements/base.in
 django-taggit==1.3.0      # via wagtail
 django-treebeard==4.3.1   # via wagtail
 django-waffle==1.0.0      # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -r requirements/base.in, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+django==2.2.14            # via -r requirements/base.in, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via wagtail
-drf-jwt==1.14.0           # via edx-drf-extensions
+drf-jwt==1.16.2           # via edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
-edx-django-utils==3.2.3   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==6.0.0  # via -r requirements/base.in
-edx-opaque-keys==2.1.0    # via edx-drf-extensions
+edx-django-utils==3.3.0   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==6.1.0  # via -r requirements/base.in
+edx-opaque-keys==2.1.1    # via edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -r requirements/base.in
 future==0.18.2            # via pyjwkest
 html5lib==1.1             # via wagtail
-idna==2.9                 # via requests
-importlib-metadata==1.6.1  # via inflect
+idna==2.10                # via requests
+importlib-metadata==1.7.0  # via inflect
 inflect==3.0.2            # via -r requirements/base.in
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 l18n==2018.5              # via wagtail
 markupsafe==1.1.1         # via jinja2
 mock==3.0.5               # via -r requirements/base.in
-mysqlclient==1.4.6        # via -r requirements/base.in
+mysqlclient==2.0.1        # via -r requirements/base.in
 newrelic==5.14.1.144      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 pbr==5.4.5                # via stevedore
-pillow==7.1.2             # via wagtail
+pillow==7.2.0             # via wagtail
 psutil==1.2.1             # via edx-django-utils
+pycparser==2.20           # via cffi
 pycryptodomex==3.9.8      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
-pyjwt==1.7.1              # via drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via edx-opaque-keys
 python-dateutil==2.8.0    # via -r requirements/base.in, edx-drf-extensions
-python3-openid==3.1.0     # via social-auth-core
+python3-openid==3.2.0     # via social-auth-core
 pytz==2020.1              # via -r requirements/base.in, django, django-modelcluster, l18n
 pyyaml==5.3.1             # via edx-django-release-util
 requests-oauthlib==1.3.0  # via social-auth-core
 requests==2.24.0          # via coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, wagtail
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
-simplejson==3.17.0        # via django-rest-swagger
-six==1.15.0               # via django-extensions, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, html5lib, l18n, mock, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
+simplejson==3.17.2        # via django-rest-swagger
+six==1.15.0               # via cryptography, django-extensions, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, html5lib, l18n, mock, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/base.in, edx-auth-backends, social-auth-app-django
@@ -68,7 +71,7 @@ stevedore==1.32.0         # via edx-opaque-keys
 unidecode==1.1.1          # via wagtail
 uritemplate==3.0.1        # via coreapi
 urllib3==1.25.9           # via requests
-wagtail==2.9              # via -r requirements/base.in
+wagtail==2.9.2            # via -r requirements/base.in
 webencodings==0.5.1       # via html5lib
 willow==1.3               # via wagtail
 xlsxwriter==1.2.9         # via wagtail

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,7 +20,7 @@ django-storages==1.9.1    # via -r requirements/base.in
 django-taggit==1.3.0      # via wagtail
 django-treebeard==4.3.1   # via wagtail
 django-waffle==1.0.0      # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
-django==2.2.14            # via -r requirements/base.in, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+django==2.2.14            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
 djangorestframework==3.11.0  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via wagtail
 drf-jwt==1.16.2           # via edx-drf-extensions
@@ -29,17 +29,17 @@ edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-utils==3.3.0   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.1.0  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via edx-drf-extensions
-edx_rest_api_client==4.0.1  # via -r requirements/base.in
+edx_rest_api_client==4.0.1  # via -c requirements/constraints.txt, -r requirements/base.in
 future==0.18.2            # via pyjwkest
 html5lib==1.1             # via wagtail
 idna==2.10                # via requests
 importlib-metadata==1.7.0  # via inflect
-inflect==3.0.2            # via -r requirements/base.in
+inflect==3.0.2            # via -c requirements/constraints.txt, -r requirements/base.in
 itypes==1.2.0             # via coreapi
 jinja2==2.11.2            # via coreschema
 l18n==2018.5              # via wagtail
 markupsafe==1.1.1         # via jinja2
-mock==3.0.5               # via -r requirements/base.in
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/base.in
 mysqlclient==2.0.1        # via -r requirements/base.in
 newrelic==5.14.1.144      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
@@ -52,7 +52,7 @@ pycryptodomex==3.9.8      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via edx-opaque-keys
-python-dateutil==2.8.0    # via -r requirements/base.in, edx-drf-extensions
+python-dateutil==2.8.0    # via -c requirements/constraints.txt, -r requirements/base.in, edx-drf-extensions
 python3-openid==3.2.0     # via social-auth-core
 pytz==2020.1              # via -r requirements/base.in, django, django-modelcluster, l18n
 pyyaml==5.3.1             # via edx-django-release-util
@@ -64,7 +64,7 @@ simplejson==3.17.2        # via django-rest-swagger
 six==1.15.0               # via cryptography, django-extensions, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, html5lib, l18n, mock, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/base.in, edx-auth-backends, social-auth-app-django
+social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.in, edx-auth-backends, social-auth-app-django
 soupsieve==2.0.1          # via beautifulsoup4
 sqlparse==0.3.1           # via django
 stevedore==1.32.0         # via edx-opaque-keys
@@ -75,4 +75,4 @@ wagtail==2.9.2            # via -r requirements/base.in
 webencodings==0.5.1       # via html5lib
 willow==1.3               # via wagtail
 xlsxwriter==1.2.9         # via wagtail
-zipp==1.2.0               # via -r requirements/base.in, importlib-metadata
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.in, importlib-metadata

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -1,0 +1,20 @@
+# Version constraints for pip-installation.
+#
+# This file doesn't install any packages. It specifies version constraints
+# that will be applied if a package is needed.
+#
+# When pinning something here, please provide an explanation of why.  Ideally,
+# link to other information that will help people in the future to remove the
+# pin when possible.  Writing an issue against the offending project and
+# linking to it here is good.
+
+Django>=2.0,<3.0
+
+edx_rest_api_client==4.0.1      # versions>4.0.1 have backward incompatible changes in timeout handling
+python-dateutil==2.8.0          # botocore has a <2.8.1 constraint. This is not a direct dependency and can be deleted (vs unpinned) when no longer needed
+zipp==1.2.0                     # greater versions dropped Python 3.5 support
+mock<4.0.0                      # mock>=4.0.0 dropped support for python3.5
+inflect<4.0.0                   # inflect>=4.0.0 dropped support for python3.5
+social-auth-core==3.2.0         # version 3.3.0 causes problems in managing fields in admin view. Can be removed once {ARCHBOM-1078} is resolved.
+mock<4.0.0                      # mock version 4.0.0 drops support for python 3.5
+

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,46 +9,48 @@ astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-cele
 attrs==19.3.0             # via -r requirements/quality.txt, pytest
 beautifulsoup4==4.8.2     # via -r requirements/quality.txt, wagtail
 certifi==2020.6.20        # via -r requirements/quality.txt, requests
+cffi==1.14.0              # via -r requirements/quality.txt, cryptography
 chardet==3.0.4            # via -r requirements/quality.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, code-annotations, edx-lint, pip-tools
 code-annotations==0.3.4   # via -r requirements/quality.txt
 coreapi==2.3.3            # via -r requirements/quality.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/quality.txt, coreapi
-coverage==5.1             # via -r requirements/quality.txt, pytest-cov
+coverage==5.2             # via -r requirements/quality.txt, pytest-cov
+cryptography==2.9.2       # via -r requirements/quality.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/quality.txt, python3-openid, social-auth-core
 diff-cover==3.0.1         # via -r requirements/dev.in
-distlib==0.3.0            # via -r requirements/quality.txt, virtualenv
+distlib==0.3.1            # via -r requirements/quality.txt, virtualenv
 django-cors-headers==3.4.0  # via -r requirements/quality.txt
 django-debug-toolbar==2.2  # via -r requirements/dev.in
 django-dynamic-fixture==3.1.0  # via -r requirements/quality.txt
-django-extensions==2.2.9  # via -r requirements/quality.txt
+django-extensions==3.0.3  # via -r requirements/quality.txt
 django-modelcluster==5.0.2  # via -r requirements/quality.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt
 django-storages==1.9.1    # via -r requirements/quality.txt
 django-taggit==1.3.0      # via -r requirements/quality.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/quality.txt, wagtail
 django-waffle==1.0.0      # via -r requirements/quality.txt, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -r requirements/quality.txt, code-annotations, django-cors-headers, django-debug-toolbar, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, wagtail
+django==2.2.14            # via -r requirements/quality.txt, code-annotations, django-cors-headers, django-debug-toolbar, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, wagtail
 djangorestframework==3.11.0  # via -r requirements/quality.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/quality.txt, wagtail
-drf-jwt==1.14.0           # via -r requirements/quality.txt, edx-drf-extensions
+drf-jwt==1.16.2           # via -r requirements/quality.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/quality.txt
 edx-django-release-util==0.4.4  # via -r requirements/quality.txt
-edx-django-utils==3.2.3   # via -r requirements/quality.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==6.0.0  # via -r requirements/quality.txt
+edx-django-utils==3.3.0   # via -r requirements/quality.txt, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==6.1.0  # via -r requirements/quality.txt
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
-edx-lint==1.4.1           # via -r requirements/quality.txt
-edx-opaque-keys==2.1.0    # via -r requirements/quality.txt, edx-drf-extensions
+edx-lint==1.5.0           # via -r requirements/quality.txt
+edx-opaque-keys==2.1.1    # via -r requirements/quality.txt, edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -r requirements/quality.txt
 factory-boy==2.12.0       # via -r requirements/quality.txt
 faker==4.1.1              # via -r requirements/quality.txt, factory-boy
 filelock==3.0.12          # via -r requirements/quality.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/quality.txt, pyjwkest
 html5lib==1.1             # via -r requirements/quality.txt, wagtail
-idna==2.9                 # via -r requirements/quality.txt, requests
-importlib-metadata==1.6.1  # via -r requirements/quality.txt, importlib-resources, inflect, path, pluggy, pytest, tox, virtualenv
-importlib-resources==2.0.1  # via -r requirements/quality.txt, virtualenv
+idna==2.10                # via -r requirements/quality.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/quality.txt, inflect, path, pluggy, pytest, tox, virtualenv
+importlib-resources==3.0.0  # via -r requirements/quality.txt, virtualenv
 inflect==3.0.2            # via -r requirements/quality.txt, jinja2-pluralize
 isort==4.3.21             # via -r requirements/quality.txt, pylint
 itypes==1.2.0             # via -r requirements/quality.txt, coreapi
@@ -60,7 +62,7 @@ markupsafe==1.1.1         # via -r requirements/quality.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
 mock==3.0.5               # via -r requirements/quality.txt
 more-itertools==8.4.0     # via -r requirements/quality.txt, pytest
-mysqlclient==1.4.6        # via -r requirements/quality.txt
+mysqlclient==2.0.1        # via -r requirements/quality.txt
 newrelic==5.14.1.144      # via -r requirements/quality.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/quality.txt, django-rest-swagger
@@ -69,38 +71,39 @@ path.py==12.4.0           # via edx-i18n-tools
 path==13.1.0              # via path.py
 pathlib2==2.3.5           # via -r requirements/quality.txt, pytest
 pbr==5.4.5                # via -r requirements/quality.txt, stevedore
-pillow==7.1.2             # via -r requirements/quality.txt, wagtail
+pillow==7.2.0             # via -r requirements/quality.txt, wagtail
 pip-tools==5.2.1          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
 psutil==1.2.1             # via -r requirements/quality.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/quality.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
+pycparser==2.20           # via -r requirements/quality.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/quality.txt, pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.txt
 pygments==2.6.1           # via diff-cover
 pyjwkest==1.4.2           # via -r requirements/quality.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/quality.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via -r requirements/quality.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
-pylint==2.4.2             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/quality.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/quality.txt, packaging
 pytest-cov==2.10.0        # via -r requirements/quality.txt
 pytest-django==3.9.0      # via -r requirements/quality.txt
 pytest==5.4.3             # via -r requirements/quality.txt, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via -r requirements/quality.txt, edx-drf-extensions, faker
-python-slugify==4.0.0     # via -r requirements/quality.txt, code-annotations
-python3-openid==3.1.0     # via -r requirements/quality.txt, social-auth-core
+python-slugify==4.0.1     # via -r requirements/quality.txt, code-annotations
+python3-openid==3.2.0     # via -r requirements/quality.txt, social-auth-core
 pytz==2020.1              # via -r requirements/quality.txt, django, django-modelcluster, l18n
 pyyaml==5.3.1             # via -r requirements/quality.txt, code-annotations, edx-django-release-util, edx-i18n-tools
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, social-auth-core
 requests==2.24.0          # via -r requirements/quality.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, wagtail
 rest-condition==1.0.3     # via -r requirements/quality.txt, edx-drf-extensions
 semantic-version==2.8.5   # via -r requirements/quality.txt, edx-drf-extensions
-simplejson==3.17.0        # via -r requirements/quality.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, astroid, diff-cover, django-dynamic-fixture, django-extensions, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, html5lib, l18n, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
+simplejson==3.17.2        # via -r requirements/quality.txt, django-rest-swagger
+six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, astroid, cryptography, diff-cover, django-dynamic-fixture, django-extensions, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, html5lib, l18n, mock, packaging, pathlib2, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/quality.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/quality.txt, edx-auth-backends
@@ -110,13 +113,13 @@ sqlparse==0.3.1           # via -r requirements/quality.txt, django, django-debu
 stevedore==1.32.0         # via -r requirements/quality.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/quality.txt, faker, python-slugify
 toml==0.10.1              # via -r requirements/quality.txt, tox
-tox==3.15.2               # via -r requirements/quality.txt
+tox==3.17.1               # via -r requirements/quality.txt
 typed-ast==1.4.1          # via -r requirements/quality.txt, astroid
 unidecode==1.1.1          # via -r requirements/quality.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/quality.txt, coreapi
 urllib3==1.25.9           # via -r requirements/quality.txt, requests
-virtualenv==20.0.25       # via -r requirements/quality.txt, tox
-wagtail==2.9              # via -r requirements/quality.txt
+virtualenv==20.0.27       # via -r requirements/quality.txt, tox
+wagtail==2.9.2            # via -r requirements/quality.txt
 wcwidth==0.2.5            # via -r requirements/quality.txt, pytest
 webencodings==0.5.1       # via -r requirements/quality.txt, html5lib
 willow==1.3               # via -r requirements/quality.txt, wagtail

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==2.2.13            # via -r requirements/base.txt, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+django==2.2.14            # via -r requirements/base.txt, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -12,36 +12,38 @@ babel==2.8.0              # via sphinx
 beautifulsoup4==4.8.2     # via -r requirements/test.txt, wagtail
 bleach==3.1.5             # via readme-renderer
 certifi==2020.6.20        # via -r requirements/test.txt, requests
+cffi==1.14.0              # via -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
 code-annotations==0.3.4   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
-coverage==5.1             # via -r requirements/test.txt, pytest-cov
+coverage==5.2             # via -r requirements/test.txt, pytest-cov
+cryptography==2.9.2       # via -r requirements/test.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
-distlib==0.3.0            # via -r requirements/test.txt, virtualenv
+distlib==0.3.1            # via -r requirements/test.txt, virtualenv
 django-cors-headers==3.4.0  # via -r requirements/test.txt
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==2.2.9  # via -r requirements/test.txt
+django-extensions==3.0.3  # via -r requirements/test.txt
 django-modelcluster==5.0.2  # via -r requirements/test.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-storages==1.9.1    # via -r requirements/test.txt
 django-taggit==1.3.0      # via -r requirements/test.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/test.txt, wagtail
 django-waffle==1.0.0      # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+django==2.2.14            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
 djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 draftjs-exporter==2.1.7   # via -r requirements/test.txt, wagtail
-drf-jwt==1.14.0           # via -r requirements/test.txt, edx-drf-extensions
+drf-jwt==1.16.2           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
-edx-django-utils==3.2.3   # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==6.0.0  # via -r requirements/test.txt
-edx-lint==1.4.1           # via -r requirements/test.txt
-edx-opaque-keys==2.1.0    # via -r requirements/test.txt, edx-drf-extensions
+edx-django-utils==3.3.0   # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==6.1.0  # via -r requirements/test.txt
+edx-lint==1.5.0           # via -r requirements/test.txt
+edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
 edx_rest_api_client==4.0.1  # via -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
@@ -49,10 +51,10 @@ faker==4.1.1              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 html5lib==1.1             # via -r requirements/test.txt, wagtail
-idna==2.9                 # via -r requirements/test.txt, requests
+idna==2.10                # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
-importlib-metadata==1.6.1  # via -r requirements/test.txt, importlib-resources, inflect, pluggy, pytest, tox, virtualenv
-importlib-resources==2.0.1  # via -r requirements/test.txt, virtualenv
+importlib-metadata==1.7.0  # via -r requirements/test.txt, inflect, pluggy, pytest, tox, virtualenv
+importlib-resources==3.0.0  # via -r requirements/test.txt, virtualenv
 inflect==3.0.2            # via -r requirements/test.txt
 isort==4.3.21             # via -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
@@ -63,33 +65,34 @@ markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
-mysqlclient==1.4.6        # via -r requirements/test.txt
+mysqlclient==2.0.1        # via -r requirements/test.txt
 newrelic==5.14.1.144      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx, tox
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/test.txt, stevedore
-pillow==7.1.2             # via -r requirements/test.txt, wagtail
+pillow==7.2.0             # via -r requirements/test.txt, wagtail
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/test.txt, pytest, tox
+pycparser==2.20           # via -r requirements/test.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/test.txt, pyjwkest
 pygments==2.6.1           # via doc8, readme-renderer, sphinx
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.4.2             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.0        # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
 pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via -r requirements/test.txt, edx-drf-extensions, faker
-python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
-python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core
+python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
+python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
 pytz==2020.1              # via -r requirements/test.txt, babel, django, django-modelcluster, l18n
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations, edx-django-release-util
 readme-renderer==26.0     # via -r requirements/doc.in
@@ -98,14 +101,14 @@ requests==2.24.0          # via -r requirements/test.txt, coreapi, edx-drf-exten
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
 restructuredtext-lint==1.3.1  # via doc8
 semantic-version==2.8.5   # via -r requirements/test.txt, edx-drf-extensions
-simplejson==3.17.0        # via -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/test.txt, astroid, bleach, django-dynamic-fixture, django-extensions, doc8, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-sphinx-theme, html5lib, l18n, mock, packaging, pathlib2, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
+simplejson==3.17.2        # via -r requirements/test.txt, django-rest-swagger
+six==1.15.0               # via -r requirements/test.txt, astroid, bleach, cryptography, django-dynamic-fixture, django-extensions, doc8, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-sphinx-theme, html5lib, l18n, mock, packaging, pathlib2, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
 soupsieve==2.0.1          # via -r requirements/test.txt, beautifulsoup4
-sphinx==3.1.1             # via -r requirements/doc.in, edx-sphinx-theme
+sphinx==3.1.2             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -116,13 +119,13 @@ sqlparse==0.3.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, doc8, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.1              # via -r requirements/test.txt, tox
-tox==3.15.2               # via -r requirements/test.txt
+tox==3.17.1               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 unidecode==1.1.1          # via -r requirements/test.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.9           # via -r requirements/test.txt, requests
-virtualenv==20.0.25       # via -r requirements/test.txt, tox
-wagtail==2.9              # via -r requirements/test.txt
+virtualenv==20.0.27       # via -r requirements/test.txt, tox
+wagtail==2.9.2            # via -r requirements/test.txt
 wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via -r requirements/test.txt, bleach, html5lib
 willow==1.3               # via -r requirements/test.txt, wagtail

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,39 +5,41 @@
 #    make upgrade
 #
 beautifulsoup4==4.8.2     # via -r requirements/base.txt, wagtail
-boto3==1.14.11            # via -r requirements/production.in
-botocore==1.17.11         # via boto3, s3transfer
+boto3==1.14.22            # via -r requirements/production.in
+botocore==1.17.22         # via boto3, s3transfer
 certifi==2020.6.20        # via -r requirements/base.txt, requests
+cffi==1.14.0              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
+cryptography==2.9.2       # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 django-cors-headers==3.4.0  # via -r requirements/base.txt
-django-extensions==2.2.9  # via -r requirements/base.txt
+django-extensions==3.0.3  # via -r requirements/base.txt
 django-modelcluster==5.0.2  # via -r requirements/base.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-storages==1.9.1    # via -r requirements/base.txt
 django-taggit==1.3.0      # via -r requirements/base.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/base.txt, wagtail
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -r requirements/base.txt, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+django==2.2.14            # via -r requirements/base.txt, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 docutils==0.15.2          # via botocore
 draftjs-exporter==2.1.7   # via -r requirements/base.txt, wagtail
-drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.16.2           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
-edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==6.0.0  # via -r requirements/base.txt
-edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.3.0   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==6.1.0  # via -r requirements/base.txt
+edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -r requirements/base.txt
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 gevent==20.6.2            # via -r requirements/production.in
 greenlet==0.4.16          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 html5lib==1.1             # via -r requirements/base.txt, wagtail
-idna==2.9                 # via -r requirements/base.txt, requests
-importlib-metadata==1.6.1  # via -r requirements/base.txt, inflect
+idna==2.10                # via -r requirements/base.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/base.txt, inflect
 inflect==3.0.2            # via -r requirements/base.txt
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
@@ -45,20 +47,21 @@ jmespath==0.10.0          # via boto3, botocore
 l18n==2018.5              # via -r requirements/base.txt, wagtail
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mock==3.0.5               # via -r requirements/base.txt
-mysqlclient==1.4.6        # via -r requirements/base.txt
+mysqlclient==2.0.1        # via -r requirements/base.txt
 newrelic==5.14.1.144      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
-pillow==7.1.2             # via -r requirements/base.txt, wagtail
+pillow==7.2.0             # via -r requirements/base.txt, wagtail
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
+pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.0    # via -r requirements/base.txt, botocore, edx-drf-extensions
 python-memcached==1.59    # via -r requirements/production.in
-python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
+python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, django, django-modelcluster, l18n
 pyyaml==5.3.1             # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
@@ -66,8 +69,8 @@ requests==2.24.0          # via -r requirements/base.txt, coreapi, edx-drf-exten
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
-simplejson==3.17.0        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, django-extensions, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, html5lib, l18n, mock, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
+simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
+six==1.15.0               # via -r requirements/base.txt, cryptography, django-extensions, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, html5lib, l18n, mock, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core, stevedore
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
@@ -77,7 +80,7 @@ stevedore==1.32.0         # via -r requirements/base.txt, edx-opaque-keys
 unidecode==1.1.1          # via -r requirements/base.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.9           # via -r requirements/base.txt, botocore, requests
-wagtail==2.9              # via -r requirements/base.txt
+wagtail==2.9.2            # via -r requirements/base.txt
 webencodings==0.5.1       # via -r requirements/base.txt, html5lib
 willow==1.3               # via -r requirements/base.txt, wagtail
 xlsxwriter==1.2.9         # via -r requirements/base.txt, wagtail

--- a/requirements/quality.in
+++ b/requirements/quality.in
@@ -2,7 +2,7 @@
 
 -r test.txt               # Core and testing dependencies for this package
 
-edx-lint==1.4.1
+edx-lint
 isort                     # to standardize order of imports
 pycodestyle               # PEP 8 compliance validation
 pydocstyle                # PEP 257 compliance validation

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -9,43 +9,45 @@ astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==19.3.0             # via -r requirements/test.txt, pytest
 beautifulsoup4==4.8.2     # via -r requirements/test.txt, wagtail
 certifi==2020.6.20        # via -r requirements/test.txt, requests
+cffi==1.14.0              # via -r requirements/test.txt, cryptography
 chardet==3.0.4            # via -r requirements/test.txt, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
 code-annotations==0.3.4   # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
-coverage==5.1             # via -r requirements/test.txt, pytest-cov
+coverage==5.2             # via -r requirements/test.txt, pytest-cov
+cryptography==2.9.2       # via -r requirements/test.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
-distlib==0.3.0            # via -r requirements/test.txt, virtualenv
+distlib==0.3.1            # via -r requirements/test.txt, virtualenv
 django-cors-headers==3.4.0  # via -r requirements/test.txt
 django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==2.2.9  # via -r requirements/test.txt
+django-extensions==3.0.3  # via -r requirements/test.txt
 django-modelcluster==5.0.2  # via -r requirements/test.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
 django-storages==1.9.1    # via -r requirements/test.txt
 django-taggit==1.3.0      # via -r requirements/test.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/test.txt, wagtail
 django-waffle==1.0.0      # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.13            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+django==2.2.14            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
 djangorestframework==3.11.0  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/test.txt, wagtail
-drf-jwt==1.14.0           # via -r requirements/test.txt, edx-drf-extensions
+drf-jwt==1.16.2           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
-edx-django-utils==3.2.3   # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==6.0.0  # via -r requirements/test.txt
-edx-lint==1.4.1           # via -r requirements/quality.in, -r requirements/test.txt
-edx-opaque-keys==2.1.0    # via -r requirements/test.txt, edx-drf-extensions
+edx-django-utils==3.3.0   # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==6.1.0  # via -r requirements/test.txt
+edx-lint==1.5.0           # via -r requirements/quality.in, -r requirements/test.txt
+edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -r requirements/test.txt
 factory-boy==2.12.0       # via -r requirements/test.txt
 faker==4.1.1              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 html5lib==1.1             # via -r requirements/test.txt, wagtail
-idna==2.9                 # via -r requirements/test.txt, requests
-importlib-metadata==1.6.1  # via -r requirements/test.txt, importlib-resources, inflect, pluggy, pytest, tox, virtualenv
-importlib-resources==2.0.1  # via -r requirements/test.txt, virtualenv
+idna==2.10                # via -r requirements/test.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/test.txt, inflect, pluggy, pytest, tox, virtualenv
+importlib-resources==3.0.0  # via -r requirements/test.txt, virtualenv
 inflect==3.0.2            # via -r requirements/test.txt
 isort==4.3.21             # via -r requirements/quality.in, -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
@@ -56,42 +58,43 @@ markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
 mock==3.0.5               # via -r requirements/test.txt
 more-itertools==8.4.0     # via -r requirements/test.txt, pytest
-mysqlclient==1.4.6        # via -r requirements/test.txt
+mysqlclient==2.0.1        # via -r requirements/test.txt
 newrelic==5.14.1.144      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 packaging==20.4           # via -r requirements/test.txt, pytest, tox
 pathlib2==2.3.5           # via -r requirements/test.txt, pytest
 pbr==5.4.5                # via -r requirements/test.txt, stevedore
-pillow==7.1.2             # via -r requirements/test.txt, wagtail
+pillow==7.2.0             # via -r requirements/test.txt, wagtail
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 psutil==1.2.1             # via -r requirements/test.txt, edx-django-utils
 py==1.9.0                 # via -r requirements/test.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.in
+pycparser==2.20           # via -r requirements/test.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/test.txt, pyjwkest
 pydocstyle==5.0.2         # via -r requirements/quality.in
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
 pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.4.2             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.0        # via -r requirements/test.txt
 pytest-django==3.9.0      # via -r requirements/test.txt
 pytest==5.4.3             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via -r requirements/test.txt, edx-drf-extensions, faker
-python-slugify==4.0.0     # via -r requirements/test.txt, code-annotations
-python3-openid==3.1.0     # via -r requirements/test.txt, social-auth-core
+python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
+python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
 pytz==2020.1              # via -r requirements/test.txt, django, django-modelcluster, l18n
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations, edx-django-release-util
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
 requests==2.24.0          # via -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, wagtail
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
 semantic-version==2.8.5   # via -r requirements/test.txt, edx-drf-extensions
-simplejson==3.17.0        # via -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/test.txt, astroid, django-dynamic-fixture, django-extensions, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, html5lib, l18n, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
+simplejson==3.17.2        # via -r requirements/test.txt, django-rest-swagger
+six==1.15.0               # via -r requirements/test.txt, astroid, cryptography, django-dynamic-fixture, django-extensions, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, html5lib, l18n, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
@@ -101,13 +104,13 @@ sqlparse==0.3.1           # via -r requirements/test.txt, django
 stevedore==1.32.0         # via -r requirements/test.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.1              # via -r requirements/test.txt, tox
-tox==3.15.2               # via -r requirements/test.txt
+tox==3.17.1               # via -r requirements/test.txt
 typed-ast==1.4.1          # via -r requirements/test.txt, astroid
 unidecode==1.1.1          # via -r requirements/test.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.25.9           # via -r requirements/test.txt, requests
-virtualenv==20.0.25       # via -r requirements/test.txt, tox
-wagtail==2.9              # via -r requirements/test.txt
+virtualenv==20.0.27       # via -r requirements/test.txt, tox
+wagtail==2.9.2            # via -r requirements/test.txt
 wcwidth==0.2.5            # via -r requirements/test.txt, pytest
 webencodings==0.5.1       # via -r requirements/test.txt, html5lib
 willow==1.3               # via -r requirements/test.txt, wagtail

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -1,5 +1,6 @@
 # Requirements for test runs.
 
+-c constraints.txt
 -r base.txt               # Core dependencies for this package
 
 code-annotations
@@ -8,8 +9,7 @@ django-dynamic-fixture    # library to create dynamic model instances for testin
 edx-lint
 Faker
 factory_boy
-# mock version 4.0.0 drops support for python 3.5
-mock<4.0.0
+mock
 pytest
 pytest-cov
 pytest-django

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -38,7 +38,7 @@ edx-django-utils==3.3.0   # via -r requirements/base.txt, edx-drf-extensions, ed
 edx-drf-extensions==6.1.0  # via -r requirements/base.txt
 edx-lint==1.5.0           # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
-edx_rest_api_client==4.0.1  # via -r requirements/base.txt
+edx_rest_api_client==4.0.1  # via -c requirements/constraints.txt, -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.1.1              # via -r requirements/test.in, factory-boy
 filelock==3.0.12          # via tox, virtualenv
@@ -47,7 +47,7 @@ html5lib==1.1             # via -r requirements/base.txt, wagtail
 idna==2.10                # via -r requirements/base.txt, requests
 importlib-metadata==1.7.0  # via -r requirements/base.txt, inflect, pluggy, pytest, tox, virtualenv
 importlib-resources==3.0.0  # via virtualenv
-inflect==3.0.2            # via -r requirements/base.txt
+inflect==3.0.2            # via -c requirements/constraints.txt, -r requirements/base.txt
 isort==4.3.21             # via pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
@@ -55,7 +55,7 @@ l18n==2018.5              # via -r requirements/base.txt, wagtail
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
-mock==3.0.5               # via -r requirements/base.txt, -r requirements/test.in
+mock==3.0.5               # via -c requirements/constraints.txt, -r requirements/base.txt, -r requirements/test.in
 more-itertools==8.4.0     # via pytest
 mysqlclient==2.0.1        # via -r requirements/base.txt
 newrelic==5.14.1.144      # via -r requirements/base.txt, edx-django-utils
@@ -81,7 +81,7 @@ pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.0        # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.3             # via -r requirements/test.in, pytest-cov, pytest-django
-python-dateutil==2.8.0    # via -r requirements/base.txt, edx-drf-extensions, faker
+python-dateutil==2.8.0    # via -c requirements/constraints.txt, -r requirements/base.txt, edx-drf-extensions, faker
 python-slugify==4.0.1     # via code-annotations
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, django, django-modelcluster, l18n
@@ -94,7 +94,7 @@ simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
 six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, django-extensions, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, html5lib, l18n, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 soupsieve==2.0.1          # via -r requirements/base.txt, beautifulsoup4
 sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, code-annotations, edx-opaque-keys
@@ -112,4 +112,4 @@ webencodings==0.5.1       # via -r requirements/base.txt, html5lib
 willow==1.3               # via -r requirements/base.txt, wagtail
 wrapt==1.11.2             # via astroid
 xlsxwriter==1.2.9         # via -r requirements/base.txt, wagtail
-zipp==1.2.0               # via -r requirements/base.txt, importlib-metadata, importlib-resources
+zipp==1.2.0               # via -c requirements/constraints.txt, -r requirements/base.txt, importlib-metadata, importlib-resources

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -9,18 +9,20 @@ astroid==2.3.3            # via pylint, pylint-celery
 attrs==19.3.0             # via pytest
 beautifulsoup4==4.8.2     # via -r requirements/base.txt, wagtail
 certifi==2020.6.20        # via -r requirements/base.txt, requests
+cffi==1.14.0              # via -r requirements/base.txt, cryptography
 chardet==3.0.4            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, code-annotations, edx-lint
 code-annotations==0.3.4   # via -r requirements/test.in
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-coverage==5.1             # via -r requirements/test.in, pytest-cov
+coverage==5.2             # via -r requirements/test.in, pytest-cov
+cryptography==2.9.2       # via -r requirements/base.txt, pyjwt
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
-distlib==0.3.0            # via virtualenv
+distlib==0.3.1            # via virtualenv
 django-cors-headers==3.4.0  # via -r requirements/base.txt
 django-dynamic-fixture==3.1.0  # via -r requirements/test.in
-django-extensions==2.2.9  # via -r requirements/base.txt
+django-extensions==3.0.3  # via -r requirements/base.txt
 django-modelcluster==5.0.2  # via -r requirements/base.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
 django-storages==1.9.1    # via -r requirements/base.txt
@@ -29,22 +31,22 @@ django-treebeard==4.3.1   # via -r requirements/base.txt, wagtail
 django-waffle==1.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
 djangorestframework==3.11.0  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/base.txt, wagtail
-drf-jwt==1.14.0           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.16.2           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
-edx-django-utils==3.2.3   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
-edx-drf-extensions==6.0.0  # via -r requirements/base.txt
-edx-lint==1.4.1           # via -r requirements/test.in
-edx-opaque-keys==2.1.0    # via -r requirements/base.txt, edx-drf-extensions
+edx-django-utils==3.3.0   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
+edx-drf-extensions==6.1.0  # via -r requirements/base.txt
+edx-lint==1.5.0           # via -r requirements/test.in
+edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -r requirements/base.txt
 factory-boy==2.12.0       # via -r requirements/test.in
 faker==4.1.1              # via -r requirements/test.in, factory-boy
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 html5lib==1.1             # via -r requirements/base.txt, wagtail
-idna==2.9                 # via -r requirements/base.txt, requests
-importlib-metadata==1.6.1  # via -r requirements/base.txt, importlib-resources, inflect, pluggy, pytest, tox, virtualenv
-importlib-resources==2.0.1  # via virtualenv
+idna==2.10                # via -r requirements/base.txt, requests
+importlib-metadata==1.7.0  # via -r requirements/base.txt, inflect, pluggy, pytest, tox, virtualenv
+importlib-resources==3.0.0  # via virtualenv
 inflect==3.0.2            # via -r requirements/base.txt
 isort==4.3.21             # via pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
@@ -55,40 +57,41 @@ markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
 mock==3.0.5               # via -r requirements/base.txt, -r requirements/test.in
 more-itertools==8.4.0     # via pytest
-mysqlclient==1.4.6        # via -r requirements/base.txt
+mysqlclient==2.0.1        # via -r requirements/base.txt
 newrelic==5.14.1.144      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 packaging==20.4           # via pytest, tox
 pathlib2==2.3.5           # via pytest
 pbr==5.4.5                # via -r requirements/base.txt, stevedore
-pillow==7.1.2             # via -r requirements/base.txt, wagtail
+pillow==7.2.0             # via -r requirements/base.txt, wagtail
 pluggy==0.13.1            # via pytest, tox
 psutil==1.2.1             # via -r requirements/base.txt, edx-django-utils
 py==1.9.0                 # via pytest, tox
+pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
-pyjwt==1.7.1              # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
+pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
 pylint-django==2.0.11     # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.2             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
 pymongo==3.10.1           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.0        # via -r requirements/test.in
 pytest-django==3.9.0      # via -r requirements/test.in
 pytest==5.4.3             # via -r requirements/test.in, pytest-cov, pytest-django
 python-dateutil==2.8.0    # via -r requirements/base.txt, edx-drf-extensions, faker
-python-slugify==4.0.0     # via code-annotations
-python3-openid==3.1.0     # via -r requirements/base.txt, social-auth-core
+python-slugify==4.0.1     # via code-annotations
+python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
 pytz==2020.1              # via -r requirements/base.txt, django, django-modelcluster, l18n
 pyyaml==5.3.1             # via -r requirements/base.txt, code-annotations, edx-django-release-util
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.24.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, wagtail
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
-simplejson==3.17.0        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, astroid, django-dynamic-fixture, django-extensions, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, html5lib, l18n, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
+simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
+six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, django-extensions, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, html5lib, l18n, mock, packaging, pathlib2, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, stevedore, tox, virtualenv
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
 social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
@@ -97,13 +100,13 @@ sqlparse==0.3.1           # via -r requirements/base.txt, django
 stevedore==1.32.0         # via -r requirements/base.txt, code-annotations, edx-opaque-keys
 text-unidecode==1.3       # via faker, python-slugify
 toml==0.10.1              # via tox
-tox==3.15.2               # via -r requirements/test.in
+tox==3.17.1               # via -r requirements/test.in
 typed-ast==1.4.1          # via astroid
 unidecode==1.1.1          # via -r requirements/base.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.25.9           # via -r requirements/base.txt, requests
-virtualenv==20.0.25       # via tox
-wagtail==2.9              # via -r requirements/base.txt
+virtualenv==20.0.27       # via tox
+wagtail==2.9.2            # via -r requirements/base.txt
 wcwidth==0.2.5            # via pytest
 webencodings==0.5.1       # via -r requirements/base.txt, html5lib
 willow==1.3               # via -r requirements/base.txt, wagtail


### PR DESCRIPTION
https://github.com/edx/portal-designer/pull/97 removed the pin for edx-lint in test.in, but bumped it to the most recent version in quality.in, which resulted in make upgrade being unable to resolve versions once it upgraded again. 

removing the pin in quaility.in seems to fix things