### PR TITLE
Update build to use Ubuntu Focal 20.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+dist: focal
 matrix:
   include:
     - python: 3.5


### PR DESCRIPTION
[MST-388](https://openedx.atlassian.net/browse/MST-388)

Updated to use Focal 20.04 rather than the default OS environment (16.04), tested build locally.