### PR TITLE
Updated the travis badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 designer  |Travis|_ |Codecov|_
 ===================================================
-.. |Travis| image:: https://travis-ci.org/edx/portal-designer.svg?branch=master
-.. _Travis: https://travis-ci.org/edx/portal-designer
+.. |Travis| image:: https://travis-ci.com/edx/portal-designer.svg?branch=master
+.. _Travis: https://travis-ci.com/edx/portal-designer
 
 .. |Codecov| image:: http://codecov.io/github/edx/portal-designer/coverage.svg?branch=master
 .. _Codecov: http://codecov.io/github/edx/portal-designer?branch=master


### PR DESCRIPTION
Updated the README file.
Travis badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089