### PR TITLE
BOM-2189 : Unpin social-auth-core

### DIFF
--- a/designer/apps/api/v1/views.py
+++ b/designer/apps/api/v1/views.py
@@ -35,8 +35,8 @@ class DesignerPagesAPIEndpoint(APIView):
         """Allows the user to 1+ Page-derived models to query"""
         try:
             models = page_models_from_string(self.request.GET.get('type', 'wagtailcore.Page'))
-        except (LookupError, ValueError):
-            raise BadRequestError("type doesn't exist")
+        except (LookupError, ValueError) as exception:
+            raise BadRequestError("type doesn't exist") from exception
 
         if not models:
             models = [Page]
@@ -122,16 +122,16 @@ class ProgramDetailView(APIView):
             return Response([])
         try:
             program_uuids = [uuid.UUID(program_uuid) for program_uuid in requested_programs.split(',')]
-        except ValueError:
-            raise serializers.ValidationError('"programs" query param contains malformed UUIDs')
+        except ValueError as exception:
+            raise serializers.ValidationError('"programs" query param contains malformed UUIDs') from exception
 
         all_programs = []
 
         for program_uuid in program_uuids:
             try:
                 program_page = ProgramPage.objects.get(uuid=program_uuid)
-            except ProgramPage.DoesNotExist:
-                raise exceptions.NotFound()
+            except ProgramPage.DoesNotExist as exception:
+                raise exceptions.NotFound() from exception
 
             frontend_url = generate_frontend_url(self.request, program_page)
 

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -18,6 +18,7 @@ edx_rest_api_client
 mysqlclient
 pytz
 python-dateutil
+social-auth-app-django
 wagtail
 zipp
 mock

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-anyascii==0.1.7           # via wagtail
 beautifulsoup4==4.8.2     # via wagtail
 certifi==2020.12.5        # via requests
 cffi==1.14.4              # via cryptography
@@ -50,7 +49,7 @@ oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 openpyxl==3.0.5           # via tablib
 pbr==5.5.1                # via stevedore
-pillow==8.1.0             # via wagtail
+pillow==7.2.0             # via wagtail
 psutil==5.8.0             # via edx-django-utils
 pycparser==2.20           # via cffi
 pycryptodomex==3.9.9      # via pyjwkest
@@ -77,7 +76,7 @@ tablib[xls,xlsx]==3.0.0   # via wagtail
 unidecode==1.1.2          # via wagtail
 uritemplate==3.0.1        # via coreapi
 urllib3==1.26.2           # via requests
-wagtail==2.11.3           # via -r requirements/base.in
+wagtail==2.10.2           # via -c requirements/constraints.txt, -r requirements/base.in
 webencodings==0.5.1       # via html5lib
 willow==1.4               # via wagtail
 xlrd==2.0.1               # via tablib

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,30 +4,32 @@
 #
 #    make upgrade
 #
+anyascii==0.1.7           # via wagtail
 beautifulsoup4==4.8.2     # via wagtail
-certifi==2020.6.20        # via requests
-cffi==1.14.3              # via cryptography
-chardet==3.0.4            # via requests
+certifi==2020.12.5        # via requests
+cffi==1.14.4              # via cryptography
+chardet==4.0.0            # via requests
 coreapi==2.3.3            # via django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via coreapi
-cryptography==3.1.1       # via pyjwt
+cryptography==3.3.1       # via pyjwt, social-auth-core
 defusedxml==0.6.0         # via python3-openid, social-auth-core
-django-cors-headers==3.5.0  # via -r requirements/base.in
-django-extensions==3.0.9  # via -r requirements/base.in
+django-cors-headers==3.6.0  # via -r requirements/base.in
+django-crum==0.7.9        # via edx-django-utils
+django-extensions==3.1.0  # via -r requirements/base.in
 django-filter==2.4.0      # via wagtail
 django-modelcluster==5.1  # via wagtail
 django-rest-swagger==2.2.0  # via -r requirements/base.in
-django-storages==1.10.1   # via -r requirements/base.in
+django-storages==1.11.1   # via -r requirements/base.in
 django-taggit==1.3.0      # via wagtail
 django-treebeard==4.3.1   # via wagtail
 django-waffle==2.0.0      # via -r requirements/base.in, edx-django-utils, edx-drf-extensions
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-filter, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
-djangorestframework==3.12.1  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/base.in, django-cors-headers, django-crum, django-filter, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+djangorestframework==3.12.2  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via wagtail
-drf-jwt==1.17.2           # via edx-drf-extensions
+drf-jwt==1.17.3           # via edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
-edx-django-utils==3.8.0   # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.13.0  # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/base.in
 edx-opaque-keys==2.1.1    # via edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -c requirements/constraints.txt, -r requirements/base.in
@@ -35,50 +37,50 @@ et-xmlfile==1.0.1         # via openpyxl
 future==0.18.2            # via pyjwkest
 html5lib==1.1             # via wagtail
 idna==2.10                # via requests
-inflect==4.1.0            # via -r requirements/base.in
+inflect==5.0.2            # via -r requirements/base.in
 itypes==1.2.0             # via coreapi
 jdcal==1.4.1              # via openpyxl
 jinja2==2.11.2            # via coreschema
-l18n==2018.5              # via wagtail
+l18n==2020.6.1            # via wagtail
 markupsafe==1.1.1         # via jinja2
-mock==4.0.2               # via -r requirements/base.in
-mysqlclient==2.0.1        # via -r requirements/base.in
-newrelic==5.20.1.150      # via edx-django-utils
+mock==4.0.3               # via -r requirements/base.in
+mysqlclient==2.0.3        # via -r requirements/base.in
+newrelic==5.24.0.153      # via edx-django-utils
 oauthlib==3.1.0           # via requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via django-rest-swagger
 openpyxl==3.0.5           # via tablib
-pbr==5.5.0                # via stevedore
-pillow==7.2.0             # via wagtail
-psutil==5.7.2             # via edx-django-utils
+pbr==5.5.1                # via stevedore
+pillow==8.1.0             # via wagtail
+psutil==5.8.0             # via edx-django-utils
 pycparser==2.20           # via cffi
-pycryptodomex==3.9.8      # via pyjwkest
+pycryptodomex==3.9.9      # via pyjwkest
 pyjwkest==1.4.2           # via edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.11.0           # via edx-opaque-keys
+pymongo==3.11.2           # via edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.in, edx-drf-extensions
 python3-openid==3.2.0     # via social-auth-core
-pytz==2020.1              # via -r requirements/base.in, django, django-modelcluster, l18n
+pytz==2020.5              # via -r requirements/base.in, django, django-modelcluster, l18n
 pyyaml==5.3.1             # via edx-django-release-util
 requests-oauthlib==1.3.0  # via social-auth-core
-requests==2.24.0          # via coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, wagtail
+requests==2.25.1          # via coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, wagtail
 rest-condition==1.0.3     # via edx-drf-extensions
 semantic-version==2.8.5   # via edx-drf-extensions
 simplejson==3.17.2        # via django-rest-swagger
 six==1.15.0               # via cryptography, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, html5lib, l18n, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via edx-rest-api-client
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/github.in, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.in, edx-auth-backends, social-auth-app-django
-soupsieve==2.0.1          # via beautifulsoup4
+social-auth-app-django==4.0.0  # via -r requirements/base.in, edx-auth-backends
+social-auth-core==3.3.3   # via -r requirements/base.in, edx-auth-backends, social-auth-app-django
+soupsieve==2.1            # via beautifulsoup4
 sqlparse==0.4.1           # via django
-stevedore==3.2.2          # via edx-django-utils, edx-opaque-keys
-tablib[xls,xlsx]==2.0.0   # via wagtail
-unidecode==1.1.1          # via wagtail
+stevedore==3.3.0          # via edx-django-utils, edx-opaque-keys
+tablib[xls,xlsx]==3.0.0   # via wagtail
+unidecode==1.1.2          # via wagtail
 uritemplate==3.0.1        # via coreapi
-urllib3==1.25.10          # via requests
-wagtail==2.10.2           # via -r requirements/base.in
+urllib3==1.26.2           # via requests
+wagtail==2.11.3           # via -r requirements/base.in
 webencodings==0.5.1       # via html5lib
 willow==1.4               # via wagtail
-xlrd==1.2.0               # via tablib
+xlrd==2.0.1               # via tablib
 xlsxwriter==1.3.7         # via wagtail
 xlwt==1.3.0               # via tablib
-zipp==3.3.0               # via -r requirements/base.in
+zipp==3.4.0               # via -r requirements/base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ django==2.2.17            # via -c requirements/constraints.txt, -r requirements
 djangorestframework==3.12.2  # via -r requirements/base.in, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via wagtail
 drf-jwt==1.17.3           # via edx-drf-extensions
-edx-auth-backends==3.1.0  # via -r requirements/base.in
+edx-auth-backends==3.3.0  # via -r requirements/base.in
 edx-django-release-util==0.4.4  # via -r requirements/base.in
 edx-django-utils==3.13.0  # via -r requirements/base.in, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/base.in
@@ -68,7 +68,7 @@ simplejson==3.17.2        # via django-rest-swagger
 six==1.15.0               # via cryptography, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, html5lib, l18n, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via edx-rest-api-client
 social-auth-app-django==4.0.0  # via -r requirements/base.in, edx-auth-backends
-social-auth-core==3.3.3   # via -r requirements/base.in, edx-auth-backends, social-auth-app-django
+social-auth-core==4.0.2   # via -r requirements/base.in, edx-auth-backends, social-auth-app-django
 soupsieve==2.1            # via beautifulsoup4
 sqlparse==0.4.1           # via django
 stevedore==3.3.0          # via edx-django-utils, edx-opaque-keys

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,4 +11,3 @@
 Django>=2.0,<3.0
 
 edx_rest_api_client==4.0.1      # versions>4.0.1 have backward incompatible changes in timeout handling
-social-auth-core==3.2.0         # version 3.3.0 causes problems in managing fields in admin view. Can be removed once {ARCHBOM-1078} is resolved.

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -11,3 +11,7 @@
 Django>=2.0,<3.0
 
 edx_rest_api_client==4.0.1      # versions>4.0.1 have backward incompatible changes in timeout handling
+
+# Newer version causing test failure with error `ModuleNotFoundError: No module named 'wagtail.core.middleware'`
+# JIRA https://openedx.atlassian.net/browse/BOM-2211 opened.
+wagtail==2.10.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -19,7 +19,7 @@ coreschema==0.0.4         # via -r requirements/quality.txt, coreapi
 coverage==5.3.1           # via -r requirements/quality.txt, pytest-cov
 cryptography==3.3.1       # via -r requirements/quality.txt, pyjwt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/quality.txt, python3-openid, social-auth-core
-diff-cover==4.1.0         # via -r requirements/dev.in
+diff-cover==4.1.1         # via -r requirements/dev.in
 distlib==0.3.1            # via -r requirements/quality.txt, virtualenv
 django-cors-headers==3.6.0  # via -r requirements/quality.txt
 django-crum==0.7.9        # via -r requirements/quality.txt, edx-django-utils
@@ -37,7 +37,7 @@ django==2.2.17            # via -c requirements/constraints.txt, -r requirements
 djangorestframework==3.12.2  # via -r requirements/quality.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/quality.txt, wagtail
 drf-jwt==1.17.3           # via -r requirements/quality.txt, edx-drf-extensions
-edx-auth-backends==3.1.0  # via -r requirements/quality.txt
+edx-auth-backends==3.3.0  # via -r requirements/quality.txt
 edx-django-release-util==0.4.4  # via -r requirements/quality.txt
 edx-django-utils==3.13.0  # via -r requirements/quality.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/quality.txt
@@ -47,7 +47,7 @@ edx-opaque-keys==2.1.1    # via -r requirements/quality.txt, edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -c requirements/constraints.txt, -r requirements/quality.txt
 et-xmlfile==1.0.1         # via -r requirements/quality.txt, openpyxl
 factory-boy==3.2.0        # via -r requirements/quality.txt
-faker==5.4.0              # via -r requirements/quality.txt, factory-boy
+faker==5.5.0              # via -r requirements/quality.txt, factory-boy
 filelock==3.0.12          # via -r requirements/quality.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/quality.txt, pyjwkest
 html5lib==1.1             # via -r requirements/quality.txt, wagtail
@@ -83,7 +83,7 @@ pycodestyle==2.6.0        # via -r requirements/quality.txt
 pycparser==2.20           # via -r requirements/quality.txt, cffi
 pycryptodomex==3.9.9      # via -r requirements/quality.txt, pyjwkest
 pydocstyle==5.1.1         # via -r requirements/quality.txt
-pygments==2.7.3           # via diff-cover
+pygments==2.7.4           # via diff-cover
 pyjwkest==1.4.2           # via -r requirements/quality.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/quality.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
@@ -109,18 +109,18 @@ six==1.15.0               # via -r requirements/quality.txt, astroid, cryptograp
 slumber==0.7.1            # via -r requirements/quality.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
 social-auth-app-django==4.0.0  # via -r requirements/quality.txt, edx-auth-backends
-social-auth-core==3.3.3   # via -r requirements/quality.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==4.0.2   # via -r requirements/quality.txt, edx-auth-backends, social-auth-app-django
 soupsieve==2.1            # via -r requirements/quality.txt, beautifulsoup4
 sqlparse==0.4.1           # via -r requirements/quality.txt, django, django-debug-toolbar
 stevedore==3.3.0          # via -r requirements/quality.txt, code-annotations, edx-django-utils, edx-opaque-keys
 tablib[xls,xlsx]==3.0.0   # via -r requirements/quality.txt, wagtail
 text-unidecode==1.3       # via -r requirements/quality.txt, faker, python-slugify
 toml==0.10.2              # via -r requirements/quality.txt, pylint, pytest, tox
-tox==3.20.1               # via -r requirements/quality.txt
+tox==3.21.0               # via -r requirements/quality.txt
 unidecode==1.1.2          # via -r requirements/quality.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/quality.txt, coreapi
 urllib3==1.26.2           # via -r requirements/quality.txt, requests
-virtualenv==20.2.2        # via -r requirements/quality.txt, tox
+virtualenv==20.3.0        # via -r requirements/quality.txt, tox
 wagtail==2.10.2           # via -c requirements/constraints.txt, -r requirements/quality.txt
 webencodings==0.5.1       # via -r requirements/quality.txt, html5lib
 willow==1.4               # via -r requirements/quality.txt, wagtail

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-anyascii==0.1.7           # via -r requirements/quality.txt, wagtail
 appdirs==1.4.4            # via -r requirements/quality.txt, virtualenv
 astroid==2.4.2            # via -r requirements/quality.txt, pylint, pylint-celery
 attrs==20.3.0             # via -r requirements/quality.txt, pytest
@@ -74,7 +73,7 @@ packaging==20.8           # via -r requirements/quality.txt, pytest, tox
 path.py==12.5.0           # via edx-i18n-tools
 path==15.0.1              # via path.py
 pbr==5.5.1                # via -r requirements/quality.txt, stevedore
-pillow==8.1.0             # via -r requirements/quality.txt, wagtail
+pillow==7.2.0             # via -r requirements/quality.txt, wagtail
 pip-tools==5.5.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
@@ -122,7 +121,7 @@ unidecode==1.1.2          # via -r requirements/quality.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/quality.txt, coreapi
 urllib3==1.26.2           # via -r requirements/quality.txt, requests
 virtualenv==20.2.2        # via -r requirements/quality.txt, tox
-wagtail==2.11.3           # via -r requirements/quality.txt
+wagtail==2.10.2           # via -c requirements/constraints.txt, -r requirements/quality.txt
 webencodings==0.5.1       # via -r requirements/quality.txt, html5lib
 willow==1.4               # via -r requirements/quality.txt, wagtail
 wrapt==1.12.1             # via -r requirements/quality.txt, astroid

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,130 +4,132 @@
 #
 #    make upgrade
 #
+anyascii==0.1.7           # via -r requirements/quality.txt, wagtail
 appdirs==1.4.4            # via -r requirements/quality.txt, virtualenv
-astroid==2.3.3            # via -r requirements/quality.txt, pylint, pylint-celery
-attrs==20.2.0             # via -r requirements/quality.txt, pytest
+astroid==2.4.2            # via -r requirements/quality.txt, pylint, pylint-celery
+attrs==20.3.0             # via -r requirements/quality.txt, pytest
 beautifulsoup4==4.8.2     # via -r requirements/quality.txt, wagtail
-certifi==2020.6.20        # via -r requirements/quality.txt, requests
-cffi==1.14.3              # via -r requirements/quality.txt, cryptography
-chardet==3.0.4            # via -r requirements/quality.txt, requests
+certifi==2020.12.5        # via -r requirements/quality.txt, requests
+cffi==1.14.4              # via -r requirements/quality.txt, cryptography
+chardet==4.0.0            # via -r requirements/quality.txt, requests
 click-log==0.3.2          # via -r requirements/quality.txt, edx-lint
 click==7.1.2              # via -r requirements/pip-tools.txt, -r requirements/quality.txt, click-log, code-annotations, edx-lint, pip-tools
-code-annotations==0.9.0   # via -r requirements/quality.txt
+code-annotations==0.10.2  # via -r requirements/quality.txt
 coreapi==2.3.3            # via -r requirements/quality.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/quality.txt, coreapi
-coverage==5.3             # via -r requirements/quality.txt, pytest-cov
-cryptography==3.1.1       # via -r requirements/quality.txt, pyjwt
+coverage==5.3.1           # via -r requirements/quality.txt, pytest-cov
+cryptography==3.3.1       # via -r requirements/quality.txt, pyjwt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/quality.txt, python3-openid, social-auth-core
-diff-cover==4.0.1         # via -r requirements/dev.in
+diff-cover==4.1.0         # via -r requirements/dev.in
 distlib==0.3.1            # via -r requirements/quality.txt, virtualenv
-django-cors-headers==3.5.0  # via -r requirements/quality.txt
-django-debug-toolbar==3.1.1  # via -r requirements/dev.in
-django-dynamic-fixture==3.1.0  # via -r requirements/quality.txt
-django-extensions==3.0.9  # via -r requirements/quality.txt
+django-cors-headers==3.6.0  # via -r requirements/quality.txt
+django-crum==0.7.9        # via -r requirements/quality.txt, edx-django-utils
+django-debug-toolbar==3.2  # via -r requirements/dev.in
+django-dynamic-fixture==3.1.1  # via -r requirements/quality.txt
+django-extensions==3.1.0  # via -r requirements/quality.txt
 django-filter==2.4.0      # via -r requirements/quality.txt, wagtail
 django-modelcluster==5.1  # via -r requirements/quality.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/quality.txt
-django-storages==1.10.1   # via -r requirements/quality.txt
+django-storages==1.11.1   # via -r requirements/quality.txt
 django-taggit==1.3.0      # via -r requirements/quality.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/quality.txt, wagtail
 django-waffle==2.0.0      # via -r requirements/quality.txt, edx-django-utils, edx-drf-extensions
-django==2.2.16            # via -c requirements/constraints.txt, -r requirements/quality.txt, code-annotations, django-cors-headers, django-debug-toolbar, django-filter, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, wagtail
-djangorestframework==3.12.1  # via -r requirements/quality.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
+django==2.2.17            # via -c requirements/constraints.txt, -r requirements/quality.txt, code-annotations, django-cors-headers, django-crum, django-debug-toolbar, django-filter, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, edx-i18n-tools, rest-condition, wagtail
+djangorestframework==3.12.2  # via -r requirements/quality.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/quality.txt, wagtail
-drf-jwt==1.17.2           # via -r requirements/quality.txt, edx-drf-extensions
+drf-jwt==1.17.3           # via -r requirements/quality.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/quality.txt
 edx-django-release-util==0.4.4  # via -r requirements/quality.txt
-edx-django-utils==3.8.0   # via -r requirements/quality.txt, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.13.0  # via -r requirements/quality.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/quality.txt
 edx-i18n-tools==0.5.3     # via -r requirements/dev.in
-edx-lint==1.5.2           # via -r requirements/quality.txt
+edx-lint==1.6             # via -r requirements/quality.txt
 edx-opaque-keys==2.1.1    # via -r requirements/quality.txt, edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -c requirements/constraints.txt, -r requirements/quality.txt
 et-xmlfile==1.0.1         # via -r requirements/quality.txt, openpyxl
-factory-boy==3.1.0        # via -r requirements/quality.txt
-faker==4.9.0              # via -r requirements/quality.txt, factory-boy
+factory-boy==3.2.0        # via -r requirements/quality.txt
+faker==5.4.0              # via -r requirements/quality.txt, factory-boy
 filelock==3.0.12          # via -r requirements/quality.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/quality.txt, pyjwkest
 html5lib==1.1             # via -r requirements/quality.txt, wagtail
 idna==2.10                # via -r requirements/quality.txt, requests
-inflect==4.1.0            # via -r requirements/quality.txt, jinja2-pluralize
-iniconfig==1.0.1          # via -r requirements/quality.txt, pytest
-isort==4.3.21             # via -r requirements/quality.txt, pylint
+inflect==5.0.2            # via -r requirements/quality.txt, jinja2-pluralize
+iniconfig==1.1.1          # via -r requirements/quality.txt, pytest
+isort==5.7.0              # via -r requirements/quality.txt, pylint
 itypes==1.2.0             # via -r requirements/quality.txt, coreapi
 jdcal==1.4.1              # via -r requirements/quality.txt, openpyxl
 jinja2-pluralize==0.3.0   # via diff-cover
 jinja2==2.11.2            # via -r requirements/quality.txt, code-annotations, coreschema, diff-cover, jinja2-pluralize
-l18n==2018.5              # via -r requirements/quality.txt, wagtail
+l18n==2020.6.1            # via -r requirements/quality.txt, wagtail
 lazy-object-proxy==1.4.3  # via -r requirements/quality.txt, astroid
 markupsafe==1.1.1         # via -r requirements/quality.txt, jinja2
 mccabe==0.6.1             # via -r requirements/quality.txt, pylint
-mock==4.0.2               # via -r requirements/quality.txt
-mysqlclient==2.0.1        # via -r requirements/quality.txt
-newrelic==5.20.1.150      # via -r requirements/quality.txt, edx-django-utils
+mock==4.0.3               # via -r requirements/quality.txt
+mysqlclient==2.0.3        # via -r requirements/quality.txt
+newrelic==5.24.0.153      # via -r requirements/quality.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/quality.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/quality.txt, django-rest-swagger
 openpyxl==3.0.5           # via -r requirements/quality.txt, tablib
-packaging==20.4           # via -r requirements/quality.txt, pytest, tox
+packaging==20.8           # via -r requirements/quality.txt, pytest, tox
 path.py==12.5.0           # via edx-i18n-tools
-path==15.0.0              # via path.py
-pbr==5.5.0                # via -r requirements/quality.txt, stevedore
-pillow==7.2.0             # via -r requirements/quality.txt, wagtail
-pip-tools==5.3.1          # via -r requirements/pip-tools.txt
+path==15.0.1              # via path.py
+pbr==5.5.1                # via -r requirements/quality.txt, stevedore
+pillow==8.1.0             # via -r requirements/quality.txt, wagtail
+pip-tools==5.5.0          # via -r requirements/pip-tools.txt
 pluggy==0.13.1            # via -r requirements/quality.txt, diff-cover, pytest, tox
 polib==1.1.0              # via edx-i18n-tools
-psutil==5.7.2             # via -r requirements/quality.txt, edx-django-utils
-py==1.9.0                 # via -r requirements/quality.txt, pytest, tox
+psutil==5.8.0             # via -r requirements/quality.txt, edx-django-utils
+py==1.10.0                # via -r requirements/quality.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.txt
 pycparser==2.20           # via -r requirements/quality.txt, cffi
-pycryptodomex==3.9.8      # via -r requirements/quality.txt, pyjwkest
+pycryptodomex==3.9.9      # via -r requirements/quality.txt, pyjwkest
 pydocstyle==5.1.1         # via -r requirements/quality.txt
-pygments==2.7.1           # via diff-cover
+pygments==2.7.3           # via diff-cover
 pyjwkest==1.4.2           # via -r requirements/quality.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/quality.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/quality.txt, edx-lint
-pylint-django==2.0.11     # via -r requirements/quality.txt, edx-lint
+pylint-django==2.3.0      # via -r requirements/quality.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/quality.txt, pylint-celery, pylint-django
-pylint==2.4.4             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.11.0           # via -r requirements/quality.txt, edx-opaque-keys
+pylint==2.6.0             # via -r requirements/quality.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.11.2           # via -r requirements/quality.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/quality.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/quality.txt
-pytest-django==3.10.0     # via -r requirements/quality.txt
-pytest==6.1.1             # via -r requirements/quality.txt, pytest-cov, pytest-django
+pytest-django==4.1.0      # via -r requirements/quality.txt
+pytest==6.2.1             # via -r requirements/quality.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/quality.txt, edx-drf-extensions, faker
 python-slugify==4.0.1     # via -r requirements/quality.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/quality.txt, social-auth-core
-pytz==2020.1              # via -r requirements/quality.txt, django, django-modelcluster, l18n
+pytz==2020.5              # via -r requirements/quality.txt, django, django-modelcluster, l18n
 pyyaml==5.3.1             # via -r requirements/quality.txt, code-annotations, edx-django-release-util, edx-i18n-tools
 requests-oauthlib==1.3.0  # via -r requirements/quality.txt, social-auth-core
-requests==2.24.0          # via -r requirements/quality.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, wagtail
+requests==2.25.1          # via -r requirements/quality.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, wagtail
 rest-condition==1.0.3     # via -r requirements/quality.txt, edx-drf-extensions
 semantic-version==2.8.5   # via -r requirements/quality.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/quality.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/pip-tools.txt, -r requirements/quality.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, html5lib, l18n, packaging, pip-tools, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, tox, virtualenv
+six==1.15.0               # via -r requirements/quality.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-i18n-tools, edx-lint, edx-opaque-keys, html5lib, l18n, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, tox, virtualenv
 slumber==0.7.1            # via -r requirements/quality.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via -r requirements/quality.txt, pydocstyle
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/quality.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/quality.txt, edx-auth-backends, social-auth-app-django
-soupsieve==2.0.1          # via -r requirements/quality.txt, beautifulsoup4
+social-auth-app-django==4.0.0  # via -r requirements/quality.txt, edx-auth-backends
+social-auth-core==3.3.3   # via -r requirements/quality.txt, edx-auth-backends, social-auth-app-django
+soupsieve==2.1            # via -r requirements/quality.txt, beautifulsoup4
 sqlparse==0.4.1           # via -r requirements/quality.txt, django, django-debug-toolbar
-stevedore==3.2.2          # via -r requirements/quality.txt, code-annotations, edx-django-utils, edx-opaque-keys
-tablib[xls,xlsx]==2.0.0   # via -r requirements/quality.txt, wagtail
+stevedore==3.3.0          # via -r requirements/quality.txt, code-annotations, edx-django-utils, edx-opaque-keys
+tablib[xls,xlsx]==3.0.0   # via -r requirements/quality.txt, wagtail
 text-unidecode==1.3       # via -r requirements/quality.txt, faker, python-slugify
-toml==0.10.1              # via -r requirements/quality.txt, pytest, tox
+toml==0.10.2              # via -r requirements/quality.txt, pylint, pytest, tox
 tox==3.20.1               # via -r requirements/quality.txt
-unidecode==1.1.1          # via -r requirements/quality.txt, wagtail
+unidecode==1.1.2          # via -r requirements/quality.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/quality.txt, coreapi
-urllib3==1.25.10          # via -r requirements/quality.txt, requests
-virtualenv==20.0.34       # via -r requirements/quality.txt, tox
-wagtail==2.10.2           # via -r requirements/quality.txt
+urllib3==1.26.2           # via -r requirements/quality.txt, requests
+virtualenv==20.2.2        # via -r requirements/quality.txt, tox
+wagtail==2.11.3           # via -r requirements/quality.txt
 webencodings==0.5.1       # via -r requirements/quality.txt, html5lib
 willow==1.4               # via -r requirements/quality.txt, wagtail
-wrapt==1.11.2             # via -r requirements/quality.txt, astroid
-xlrd==1.2.0               # via -r requirements/quality.txt, tablib
+wrapt==1.12.1             # via -r requirements/quality.txt, astroid
+xlrd==2.0.1               # via -r requirements/quality.txt, tablib
 xlsxwriter==1.3.7         # via -r requirements/quality.txt, wagtail
 xlwt==1.3.0               # via -r requirements/quality.txt, tablib
-zipp==3.3.0               # via -r requirements/quality.txt
+zipp==3.4.0               # via -r requirements/quality.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/django.txt
+++ b/requirements/django.txt
@@ -1,1 +1,1 @@
-django==2.2.16            # via -r requirements/base.txt, django-cors-headers, django-filter, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+django==2.2.17            # via -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,7 +5,6 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
-anyascii==0.1.7           # via -r requirements/test.txt, wagtail
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
 astroid==2.4.2            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==20.3.0             # via -r requirements/test.txt, pytest
@@ -75,7 +74,7 @@ openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 openpyxl==3.0.5           # via -r requirements/test.txt, tablib
 packaging==20.8           # via -r requirements/test.txt, bleach, pytest, sphinx, tox
 pbr==5.5.1                # via -r requirements/test.txt, stevedore
-pillow==8.1.0             # via -r requirements/test.txt, wagtail
+pillow==7.2.0             # via -r requirements/test.txt, wagtail
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
 py==1.10.0                # via -r requirements/test.txt, pytest, tox
@@ -128,7 +127,7 @@ unidecode==1.1.2          # via -r requirements/test.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.26.2           # via -r requirements/test.txt, requests
 virtualenv==20.2.2        # via -r requirements/test.txt, tox
-wagtail==2.11.3           # via -r requirements/test.txt
+wagtail==2.10.2           # via -r requirements/test.txt
 webencodings==0.5.1       # via -r requirements/test.txt, bleach, html5lib
 willow==1.4               # via -r requirements/test.txt, wagtail
 wrapt==1.12.1             # via -r requirements/test.txt, astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -40,7 +40,7 @@ doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 draftjs-exporter==2.1.7   # via -r requirements/test.txt, wagtail
 drf-jwt==1.17.3           # via -r requirements/test.txt, edx-drf-extensions
-edx-auth-backends==3.1.0  # via -r requirements/test.txt
+edx-auth-backends==3.3.0  # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
 edx-django-utils==3.13.0  # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/test.txt
@@ -50,7 +50,7 @@ edx-sphinx-theme==1.6.0   # via -r requirements/doc.in
 edx_rest_api_client==4.0.1  # via -r requirements/test.txt
 et-xmlfile==1.0.1         # via -r requirements/test.txt, openpyxl
 factory-boy==3.2.0        # via -r requirements/test.txt
-faker==5.4.0              # via -r requirements/test.txt, factory-boy
+faker==5.5.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 html5lib==1.1             # via -r requirements/test.txt, wagtail
@@ -80,7 +80,7 @@ psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
 py==1.10.0                # via -r requirements/test.txt, pytest, tox
 pycparser==2.20           # via -r requirements/test.txt, cffi
 pycryptodomex==3.9.9      # via -r requirements/test.txt, pyjwkest
-pygments==2.7.3           # via doc8, readme-renderer, sphinx
+pygments==2.7.4           # via doc8, readme-renderer, sphinx
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
@@ -108,7 +108,7 @@ six==1.15.0               # via -r requirements/test.txt, astroid, bleach, crypt
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
 social-auth-app-django==4.0.0  # via -r requirements/test.txt, edx-auth-backends
-social-auth-core==3.3.3   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==4.0.2   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
 soupsieve==2.1            # via -r requirements/test.txt, beautifulsoup4
 sphinx==3.4.3             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
@@ -122,11 +122,11 @@ stevedore==3.3.0          # via -r requirements/test.txt, code-annotations, doc8
 tablib[xls,xlsx]==3.0.0   # via -r requirements/test.txt, wagtail
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.2              # via -r requirements/test.txt, pylint, pytest, tox
-tox==3.20.1               # via -r requirements/test.txt
+tox==3.21.0               # via -r requirements/test.txt
 unidecode==1.1.2          # via -r requirements/test.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.26.2           # via -r requirements/test.txt, requests
-virtualenv==20.2.2        # via -r requirements/test.txt, tox
+virtualenv==20.3.0        # via -r requirements/test.txt, tox
 wagtail==2.10.2           # via -r requirements/test.txt
 webencodings==0.5.1       # via -r requirements/test.txt, bleach, html5lib
 willow==1.4               # via -r requirements/test.txt, wagtail

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -5,111 +5,113 @@
 #    make upgrade
 #
 alabaster==0.7.12         # via sphinx
+anyascii==0.1.7           # via -r requirements/test.txt, wagtail
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
-astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
-attrs==20.2.0             # via -r requirements/test.txt, pytest
-babel==2.8.0              # via sphinx
+astroid==2.4.2            # via -r requirements/test.txt, pylint, pylint-celery
+attrs==20.3.0             # via -r requirements/test.txt, pytest
+babel==2.9.0              # via sphinx
 beautifulsoup4==4.8.2     # via -r requirements/test.txt, wagtail
 bleach==3.2.1             # via readme-renderer
-certifi==2020.6.20        # via -r requirements/test.txt, requests
-cffi==1.14.3              # via -r requirements/test.txt, cryptography
-chardet==3.0.4            # via -r requirements/test.txt, doc8, requests
+certifi==2020.12.5        # via -r requirements/test.txt, requests
+cffi==1.14.4              # via -r requirements/test.txt, cryptography
+chardet==4.0.0            # via -r requirements/test.txt, doc8, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==0.9.0   # via -r requirements/test.txt
+code-annotations==0.10.2  # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
-coverage==5.3             # via -r requirements/test.txt, pytest-cov
-cryptography==3.1.1       # via -r requirements/test.txt, pyjwt
+coverage==5.3.1           # via -r requirements/test.txt, pytest-cov
+cryptography==3.3.1       # via -r requirements/test.txt, pyjwt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
 distlib==0.3.1            # via -r requirements/test.txt, virtualenv
-django-cors-headers==3.5.0  # via -r requirements/test.txt
-django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.9  # via -r requirements/test.txt
+django-cors-headers==3.6.0  # via -r requirements/test.txt
+django-crum==0.7.9        # via -r requirements/test.txt, edx-django-utils
+django-dynamic-fixture==3.1.1  # via -r requirements/test.txt
+django-extensions==3.1.0  # via -r requirements/test.txt
 django-filter==2.4.0      # via -r requirements/test.txt, wagtail
 django-modelcluster==5.1  # via -r requirements/test.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
-django-storages==1.10.1   # via -r requirements/test.txt
+django-storages==1.11.1   # via -r requirements/test.txt
 django-taggit==1.3.0      # via -r requirements/test.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/test.txt, wagtail
 django-waffle==2.0.0      # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.16            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-filter, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
-djangorestframework==3.12.1  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
+django==2.2.17            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+djangorestframework==3.12.2  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 doc8==0.8.1               # via -r requirements/doc.in
 docutils==0.16            # via doc8, readme-renderer, restructuredtext-lint, sphinx
 draftjs-exporter==2.1.7   # via -r requirements/test.txt, wagtail
-drf-jwt==1.17.2           # via -r requirements/test.txt, edx-drf-extensions
+drf-jwt==1.17.3           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
-edx-django-utils==3.8.0   # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.13.0  # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/test.txt
-edx-lint==1.5.2           # via -r requirements/test.txt
+edx-lint==1.6             # via -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
-edx-sphinx-theme==1.5.0   # via -r requirements/doc.in
+edx-sphinx-theme==1.6.0   # via -r requirements/doc.in
 edx_rest_api_client==4.0.1  # via -r requirements/test.txt
 et-xmlfile==1.0.1         # via -r requirements/test.txt, openpyxl
-factory-boy==3.1.0        # via -r requirements/test.txt
-faker==4.9.0              # via -r requirements/test.txt, factory-boy
+factory-boy==3.2.0        # via -r requirements/test.txt
+faker==5.4.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 html5lib==1.1             # via -r requirements/test.txt, wagtail
 idna==2.10                # via -r requirements/test.txt, requests
 imagesize==1.2.0          # via sphinx
-inflect==4.1.0            # via -r requirements/test.txt
-iniconfig==1.0.1          # via -r requirements/test.txt, pytest
-isort==4.3.21             # via -r requirements/test.txt, pylint
+inflect==5.0.2            # via -r requirements/test.txt
+iniconfig==1.1.1          # via -r requirements/test.txt, pytest
+isort==5.7.0              # via -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jdcal==1.4.1              # via -r requirements/test.txt, openpyxl
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema, sphinx
-l18n==2018.5              # via -r requirements/test.txt, wagtail
+l18n==2020.6.1            # via -r requirements/test.txt, wagtail
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
-mock==4.0.2               # via -r requirements/test.txt
-mysqlclient==2.0.1        # via -r requirements/test.txt
-newrelic==5.20.1.150      # via -r requirements/test.txt, edx-django-utils
+mock==4.0.3               # via -r requirements/test.txt
+mysqlclient==2.0.3        # via -r requirements/test.txt
+newrelic==5.24.0.153      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 openpyxl==3.0.5           # via -r requirements/test.txt, tablib
-packaging==20.4           # via -r requirements/test.txt, bleach, pytest, sphinx, tox
-pbr==5.5.0                # via -r requirements/test.txt, stevedore
-pillow==7.2.0             # via -r requirements/test.txt, wagtail
+packaging==20.8           # via -r requirements/test.txt, bleach, pytest, sphinx, tox
+pbr==5.5.1                # via -r requirements/test.txt, stevedore
+pillow==8.1.0             # via -r requirements/test.txt, wagtail
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
-psutil==5.7.2             # via -r requirements/test.txt, edx-django-utils
-py==1.9.0                 # via -r requirements/test.txt, pytest, tox
+psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
+py==1.10.0                # via -r requirements/test.txt, pytest, tox
 pycparser==2.20           # via -r requirements/test.txt, cffi
-pycryptodomex==3.9.8      # via -r requirements/test.txt, pyjwkest
-pygments==2.7.1           # via doc8, readme-renderer, sphinx
+pycryptodomex==3.9.9      # via -r requirements/test.txt, pyjwkest
+pygments==2.7.3           # via doc8, readme-renderer, sphinx
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
-pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
+pylint-django==2.3.0      # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.11.0           # via -r requirements/test.txt, edx-opaque-keys
+pylint==2.6.0             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.11.2           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
-pytest-django==3.10.0     # via -r requirements/test.txt
-pytest==6.1.1             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest-django==4.1.0      # via -r requirements/test.txt
+pytest==6.2.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
-pytz==2020.1              # via -r requirements/test.txt, babel, django, django-modelcluster, l18n
+pytz==2020.5              # via -r requirements/test.txt, babel, django, django-modelcluster, l18n
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations, edx-django-release-util
-readme-renderer==27.0     # via -r requirements/doc.in
+readme-renderer==28.0     # via -r requirements/doc.in
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
-requests==2.24.0          # via -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx, wagtail
+requests==2.25.1          # via -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, sphinx, wagtail
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
-restructuredtext-lint==1.3.1  # via doc8
+restructuredtext-lint==1.3.2  # via doc8
 semantic-version==2.8.5   # via -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/test.txt, astroid, bleach, cryptography, django-dynamic-fixture, doc8, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-sphinx-theme, html5lib, l18n, packaging, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, tox, virtualenv
+six==1.15.0               # via -r requirements/test.txt, astroid, bleach, cryptography, django-dynamic-fixture, doc8, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, edx-sphinx-theme, html5lib, l18n, pyjwkest, python-dateutil, readme-renderer, social-auth-app-django, social-auth-core, tox, virtualenv
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via sphinx
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-soupsieve==2.0.1          # via -r requirements/test.txt, beautifulsoup4
-sphinx==3.2.1             # via -r requirements/doc.in, edx-sphinx-theme
+social-auth-app-django==4.0.0  # via -r requirements/test.txt, edx-auth-backends
+social-auth-core==3.3.3   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+soupsieve==2.1            # via -r requirements/test.txt, beautifulsoup4
+sphinx==3.4.3             # via -r requirements/doc.in, edx-sphinx-theme
 sphinxcontrib-applehelp==1.0.2  # via sphinx
 sphinxcontrib-devhelp==1.0.2  # via sphinx
 sphinxcontrib-htmlhelp==1.0.3  # via sphinx
@@ -117,23 +119,23 @@ sphinxcontrib-jsmath==1.0.1  # via sphinx
 sphinxcontrib-qthelp==1.0.3  # via sphinx
 sphinxcontrib-serializinghtml==1.1.4  # via sphinx
 sqlparse==0.4.1           # via -r requirements/test.txt, django
-stevedore==3.2.2          # via -r requirements/test.txt, code-annotations, doc8, edx-django-utils, edx-opaque-keys
-tablib[xls,xlsx]==2.0.0   # via -r requirements/test.txt, wagtail
+stevedore==3.3.0          # via -r requirements/test.txt, code-annotations, doc8, edx-django-utils, edx-opaque-keys
+tablib[xls,xlsx]==3.0.0   # via -r requirements/test.txt, wagtail
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
-toml==0.10.1              # via -r requirements/test.txt, pytest, tox
+toml==0.10.2              # via -r requirements/test.txt, pylint, pytest, tox
 tox==3.20.1               # via -r requirements/test.txt
-unidecode==1.1.1          # via -r requirements/test.txt, wagtail
+unidecode==1.1.2          # via -r requirements/test.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
-urllib3==1.25.10          # via -r requirements/test.txt, requests
-virtualenv==20.0.34       # via -r requirements/test.txt, tox
-wagtail==2.10.2           # via -r requirements/test.txt
+urllib3==1.26.2           # via -r requirements/test.txt, requests
+virtualenv==20.2.2        # via -r requirements/test.txt, tox
+wagtail==2.11.3           # via -r requirements/test.txt
 webencodings==0.5.1       # via -r requirements/test.txt, bleach, html5lib
 willow==1.4               # via -r requirements/test.txt, wagtail
-wrapt==1.11.2             # via -r requirements/test.txt, astroid
-xlrd==1.2.0               # via -r requirements/test.txt, tablib
+wrapt==1.12.1             # via -r requirements/test.txt, astroid
+xlrd==2.0.1               # via -r requirements/test.txt, tablib
 xlsxwriter==1.3.7         # via -r requirements/test.txt, wagtail
 xlwt==1.3.0               # via -r requirements/test.txt, tablib
-zipp==3.3.0               # via -r requirements/test.txt
+zipp==3.4.0               # via -r requirements/test.txt
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/github.in
+++ b/requirements/github.in
@@ -1,5 +1,1 @@
 #Forks and other dependencies not yet on PyPI
-
-# Forked to get Django 2.2 support from unreleased master branch from social-app-django repo.
-# This can be removed once an official social-auth-app-django Pypi release with Django 2.2 support is available in the future.
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -5,8 +5,7 @@
 #    make upgrade
 #
 click==7.1.2              # via pip-tools
-pip-tools==5.3.1          # via -r requirements/pip-tools.in
-six==1.15.0               # via pip-tools
+pip-tools==5.5.0          # via -r requirements/pip-tools.in
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,94 +4,96 @@
 #
 #    make upgrade
 #
+anyascii==0.1.7           # via -r requirements/base.txt, wagtail
 beautifulsoup4==4.8.2     # via -r requirements/base.txt, wagtail
-boto3==1.15.16            # via -r requirements/production.in
-botocore==1.18.16         # via boto3, s3transfer
-certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.3              # via -r requirements/base.txt, cryptography
-chardet==3.0.4            # via -r requirements/base.txt, requests
+boto3==1.16.51            # via -r requirements/production.in
+botocore==1.19.51         # via boto3, s3transfer
+certifi==2020.12.5        # via -r requirements/base.txt, requests
+cffi==1.14.4              # via -r requirements/base.txt, cryptography
+chardet==4.0.0            # via -r requirements/base.txt, requests
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-cryptography==3.1.1       # via -r requirements/base.txt, pyjwt
+cryptography==3.3.1       # via -r requirements/base.txt, pyjwt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
-django-cors-headers==3.5.0  # via -r requirements/base.txt
-django-extensions==3.0.9  # via -r requirements/base.txt
+django-cors-headers==3.6.0  # via -r requirements/base.txt
+django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils
+django-extensions==3.1.0  # via -r requirements/base.txt
 django-filter==2.4.0      # via -r requirements/base.txt, wagtail
 django-modelcluster==5.1  # via -r requirements/base.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
-django-storages==1.10.1   # via -r requirements/base.txt
+django-storages==1.11.1   # via -r requirements/base.txt
 django-taggit==1.3.0      # via -r requirements/base.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/base.txt, wagtail
 django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-django==2.2.16            # via -r requirements/base.txt, django-cors-headers, django-filter, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
-djangorestframework==3.12.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
+django==2.2.17            # via -r requirements/base.txt, django-cors-headers, django-crum, django-filter, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/base.txt, wagtail
-drf-jwt==1.17.2           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.17.3           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
-edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/base.txt
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -r requirements/base.txt
 et-xmlfile==1.0.1         # via -r requirements/base.txt, openpyxl
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
-gevent==20.9.0            # via -r requirements/production.in
+gevent==20.12.1           # via -r requirements/production.in
 greenlet==0.4.17          # via gevent
 gunicorn==20.0.4          # via -r requirements/production.in
 html5lib==1.1             # via -r requirements/base.txt, wagtail
 idna==2.10                # via -r requirements/base.txt, requests
-inflect==4.1.0            # via -r requirements/base.txt
+inflect==5.0.2            # via -r requirements/base.txt
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jdcal==1.4.1              # via -r requirements/base.txt, openpyxl
 jinja2==2.11.2            # via -r requirements/base.txt, coreschema
 jmespath==0.10.0          # via boto3, botocore
-l18n==2018.5              # via -r requirements/base.txt, wagtail
+l18n==2020.6.1            # via -r requirements/base.txt, wagtail
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
-mock==4.0.2               # via -r requirements/base.txt
-mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.20.1.150      # via -r requirements/base.txt, edx-django-utils
+mock==4.0.3               # via -r requirements/base.txt
+mysqlclient==2.0.3        # via -r requirements/base.txt
+newrelic==5.24.0.153      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 openpyxl==3.0.5           # via -r requirements/base.txt, tablib
-pbr==5.5.0                # via -r requirements/base.txt, stevedore
-pillow==7.2.0             # via -r requirements/base.txt, wagtail
-psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
+pbr==5.5.1                # via -r requirements/base.txt, stevedore
+pillow==8.1.0             # via -r requirements/base.txt, wagtail
+psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
 pycparser==2.20           # via -r requirements/base.txt, cffi
-pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
+pycryptodomex==3.9.9      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
-pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
+pymongo==3.11.2           # via -r requirements/base.txt, edx-opaque-keys
 python-dateutil==2.8.1    # via -r requirements/base.txt, botocore, edx-drf-extensions
 python-memcached==1.59    # via -r requirements/production.in
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2020.1              # via -r requirements/base.txt, django, django-modelcluster, l18n
+pytz==2020.5              # via -r requirements/base.txt, django, django-modelcluster, l18n
 pyyaml==5.3.1             # via -r requirements/base.txt, -r requirements/production.in, edx-django-release-util
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.24.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, wagtail
+requests==2.25.1          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, wagtail
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 s3transfer==0.3.3         # via boto3
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
 six==1.15.0               # via -r requirements/base.txt, cryptography, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, html5lib, l18n, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
-soupsieve==2.0.1          # via -r requirements/base.txt, beautifulsoup4
+social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
+social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+soupsieve==2.1            # via -r requirements/base.txt, beautifulsoup4
 sqlparse==0.4.1           # via -r requirements/base.txt, django
-stevedore==3.2.2          # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
-tablib[xls,xlsx]==2.0.0   # via -r requirements/base.txt, wagtail
-unidecode==1.1.1          # via -r requirements/base.txt, wagtail
+stevedore==3.3.0          # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys
+tablib[xls,xlsx]==3.0.0   # via -r requirements/base.txt, wagtail
+unidecode==1.1.2          # via -r requirements/base.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.10          # via -r requirements/base.txt, botocore, requests
-wagtail==2.10.2           # via -r requirements/base.txt
+urllib3==1.26.2           # via -r requirements/base.txt, botocore, requests
+wagtail==2.11.3           # via -r requirements/base.txt
 webencodings==0.5.1       # via -r requirements/base.txt, html5lib
 willow==1.4               # via -r requirements/base.txt, wagtail
-xlrd==1.2.0               # via -r requirements/base.txt, tablib
+xlrd==2.0.1               # via -r requirements/base.txt, tablib
 xlsxwriter==1.3.7         # via -r requirements/base.txt, wagtail
 xlwt==1.3.0               # via -r requirements/base.txt, tablib
-zipp==3.3.0               # via -r requirements/base.txt
+zipp==3.4.0               # via -r requirements/base.txt
 zope.event==4.5.0         # via gevent
-zope.interface==5.1.2     # via gevent
+zope.interface==5.2.0     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-anyascii==0.1.7           # via -r requirements/base.txt, wagtail
 beautifulsoup4==4.8.2     # via -r requirements/base.txt, wagtail
 boto3==1.16.51            # via -r requirements/production.in
 botocore==1.19.51         # via boto3, s3transfer
@@ -56,7 +55,7 @@ oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, soc
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 openpyxl==3.0.5           # via -r requirements/base.txt, tablib
 pbr==5.5.1                # via -r requirements/base.txt, stevedore
-pillow==8.1.0             # via -r requirements/base.txt, wagtail
+pillow==7.2.0             # via -r requirements/base.txt, wagtail
 psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
 pycparser==2.20           # via -r requirements/base.txt, cffi
 pycryptodomex==3.9.9      # via -r requirements/base.txt, pyjwkest
@@ -85,7 +84,7 @@ tablib[xls,xlsx]==3.0.0   # via -r requirements/base.txt, wagtail
 unidecode==1.1.2          # via -r requirements/base.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.26.2           # via -r requirements/base.txt, botocore, requests
-wagtail==2.11.3           # via -r requirements/base.txt
+wagtail==2.10.2           # via -r requirements/base.txt
 webencodings==0.5.1       # via -r requirements/base.txt, html5lib
 willow==1.4               # via -r requirements/base.txt, wagtail
 xlrd==2.0.1               # via -r requirements/base.txt, tablib

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -5,8 +5,8 @@
 #    make upgrade
 #
 beautifulsoup4==4.8.2     # via -r requirements/base.txt, wagtail
-boto3==1.16.51            # via -r requirements/production.in
-botocore==1.19.51         # via boto3, s3transfer
+boto3==1.16.52            # via -r requirements/production.in
+botocore==1.19.52         # via boto3, s3transfer
 certifi==2020.12.5        # via -r requirements/base.txt, requests
 cffi==1.14.4              # via -r requirements/base.txt, cryptography
 chardet==4.0.0            # via -r requirements/base.txt, requests
@@ -28,7 +28,7 @@ django==2.2.17            # via -r requirements/base.txt, django-cors-headers, d
 djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/base.txt, wagtail
 drf-jwt==1.17.3           # via -r requirements/base.txt, edx-drf-extensions
-edx-auth-backends==3.1.0  # via -r requirements/base.txt
+edx-auth-backends==3.3.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/base.txt
@@ -70,13 +70,13 @@ pyyaml==5.3.1             # via -r requirements/base.txt, -r requirements/produc
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
 requests==2.25.1          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, wagtail
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
-s3transfer==0.3.3         # via boto3
+s3transfer==0.3.4         # via boto3
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
 six==1.15.0               # via -r requirements/base.txt, cryptography, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-opaque-keys, html5lib, l18n, pyjwkest, python-dateutil, python-memcached, social-auth-app-django, social-auth-core
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==4.0.2   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 soupsieve==2.1            # via -r requirements/base.txt, beautifulsoup4
 sqlparse==0.4.1           # via -r requirements/base.txt, django
 stevedore==3.3.0          # via -r requirements/base.txt, edx-django-utils, edx-opaque-keys

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -35,7 +35,7 @@ django==2.2.17            # via -r requirements/test.txt, code-annotations, djan
 djangorestframework==3.12.2  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/test.txt, wagtail
 drf-jwt==1.17.3           # via -r requirements/test.txt, edx-drf-extensions
-edx-auth-backends==3.1.0  # via -r requirements/test.txt
+edx-auth-backends==3.3.0  # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
 edx-django-utils==3.13.0  # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/test.txt
@@ -44,7 +44,7 @@ edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -r requirements/test.txt
 et-xmlfile==1.0.1         # via -r requirements/test.txt, openpyxl
 factory-boy==3.2.0        # via -r requirements/test.txt
-faker==5.4.0              # via -r requirements/test.txt, factory-boy
+faker==5.5.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 html5lib==1.1             # via -r requirements/test.txt, wagtail
@@ -100,18 +100,18 @@ six==1.15.0               # via -r requirements/test.txt, astroid, cryptography,
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
 social-auth-app-django==4.0.0  # via -r requirements/test.txt, edx-auth-backends
-social-auth-core==3.3.3   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==4.0.2   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
 soupsieve==2.1            # via -r requirements/test.txt, beautifulsoup4
 sqlparse==0.4.1           # via -r requirements/test.txt, django
 stevedore==3.3.0          # via -r requirements/test.txt, code-annotations, edx-django-utils, edx-opaque-keys
 tablib[xls,xlsx]==3.0.0   # via -r requirements/test.txt, wagtail
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
 toml==0.10.2              # via -r requirements/test.txt, pylint, pytest, tox
-tox==3.20.1               # via -r requirements/test.txt
+tox==3.21.0               # via -r requirements/test.txt
 unidecode==1.1.2          # via -r requirements/test.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.26.2           # via -r requirements/test.txt, requests
-virtualenv==20.2.2        # via -r requirements/test.txt, tox
+virtualenv==20.3.0        # via -r requirements/test.txt, tox
 wagtail==2.10.2           # via -r requirements/test.txt
 webencodings==0.5.1       # via -r requirements/test.txt, html5lib
 willow==1.4               # via -r requirements/test.txt, wagtail

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,118 +4,120 @@
 #
 #    make upgrade
 #
+anyascii==0.1.7           # via -r requirements/test.txt, wagtail
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
-astroid==2.3.3            # via -r requirements/test.txt, pylint, pylint-celery
-attrs==20.2.0             # via -r requirements/test.txt, pytest
+astroid==2.4.2            # via -r requirements/test.txt, pylint, pylint-celery
+attrs==20.3.0             # via -r requirements/test.txt, pytest
 beautifulsoup4==4.8.2     # via -r requirements/test.txt, wagtail
-certifi==2020.6.20        # via -r requirements/test.txt, requests
-cffi==1.14.3              # via -r requirements/test.txt, cryptography
-chardet==3.0.4            # via -r requirements/test.txt, requests
+certifi==2020.12.5        # via -r requirements/test.txt, requests
+cffi==1.14.4              # via -r requirements/test.txt, cryptography
+chardet==4.0.0            # via -r requirements/test.txt, requests
 click-log==0.3.2          # via -r requirements/test.txt, edx-lint
 click==7.1.2              # via -r requirements/test.txt, click-log, code-annotations, edx-lint
-code-annotations==0.9.0   # via -r requirements/test.txt
+code-annotations==0.10.2  # via -r requirements/test.txt
 coreapi==2.3.3            # via -r requirements/test.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/test.txt, coreapi
-coverage==5.3             # via -r requirements/test.txt, pytest-cov
-cryptography==3.1.1       # via -r requirements/test.txt, pyjwt
+coverage==5.3.1           # via -r requirements/test.txt, pytest-cov
+cryptography==3.3.1       # via -r requirements/test.txt, pyjwt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/test.txt, python3-openid, social-auth-core
 distlib==0.3.1            # via -r requirements/test.txt, virtualenv
-django-cors-headers==3.5.0  # via -r requirements/test.txt
-django-dynamic-fixture==3.1.0  # via -r requirements/test.txt
-django-extensions==3.0.9  # via -r requirements/test.txt
+django-cors-headers==3.6.0  # via -r requirements/test.txt
+django-crum==0.7.9        # via -r requirements/test.txt, edx-django-utils
+django-dynamic-fixture==3.1.1  # via -r requirements/test.txt
+django-extensions==3.1.0  # via -r requirements/test.txt
 django-filter==2.4.0      # via -r requirements/test.txt, wagtail
 django-modelcluster==5.1  # via -r requirements/test.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/test.txt
-django-storages==1.10.1   # via -r requirements/test.txt
+django-storages==1.11.1   # via -r requirements/test.txt
 django-taggit==1.3.0      # via -r requirements/test.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/test.txt, wagtail
 django-waffle==2.0.0      # via -r requirements/test.txt, edx-django-utils, edx-drf-extensions
-django==2.2.16            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-filter, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
-djangorestframework==3.12.1  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
+django==2.2.17            # via -r requirements/test.txt, code-annotations, django-cors-headers, django-crum, django-filter, django-storages, django-taggit, django-treebeard, djangorestframework, drf-jwt, edx-auth-backends, edx-django-release-util, edx-django-utils, edx-drf-extensions, rest-condition, wagtail
+djangorestframework==3.12.2  # via -r requirements/test.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/test.txt, wagtail
-drf-jwt==1.17.2           # via -r requirements/test.txt, edx-drf-extensions
+drf-jwt==1.17.3           # via -r requirements/test.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/test.txt
 edx-django-release-util==0.4.4  # via -r requirements/test.txt
-edx-django-utils==3.8.0   # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.13.0  # via -r requirements/test.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/test.txt
-edx-lint==1.5.2           # via -r requirements/quality.in, -r requirements/test.txt
+edx-lint==1.6             # via -r requirements/quality.in, -r requirements/test.txt
 edx-opaque-keys==2.1.1    # via -r requirements/test.txt, edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -r requirements/test.txt
 et-xmlfile==1.0.1         # via -r requirements/test.txt, openpyxl
-factory-boy==3.1.0        # via -r requirements/test.txt
-faker==4.9.0              # via -r requirements/test.txt, factory-boy
+factory-boy==3.2.0        # via -r requirements/test.txt
+faker==5.4.0              # via -r requirements/test.txt, factory-boy
 filelock==3.0.12          # via -r requirements/test.txt, tox, virtualenv
 future==0.18.2            # via -r requirements/test.txt, pyjwkest
 html5lib==1.1             # via -r requirements/test.txt, wagtail
 idna==2.10                # via -r requirements/test.txt, requests
-inflect==4.1.0            # via -r requirements/test.txt
-iniconfig==1.0.1          # via -r requirements/test.txt, pytest
-isort==4.3.21             # via -r requirements/quality.in, -r requirements/test.txt, pylint
+inflect==5.0.2            # via -r requirements/test.txt
+iniconfig==1.1.1          # via -r requirements/test.txt, pytest
+isort==5.7.0              # via -r requirements/quality.in, -r requirements/test.txt, pylint
 itypes==1.2.0             # via -r requirements/test.txt, coreapi
 jdcal==1.4.1              # via -r requirements/test.txt, openpyxl
 jinja2==2.11.2            # via -r requirements/test.txt, code-annotations, coreschema
-l18n==2018.5              # via -r requirements/test.txt, wagtail
+l18n==2020.6.1            # via -r requirements/test.txt, wagtail
 lazy-object-proxy==1.4.3  # via -r requirements/test.txt, astroid
 markupsafe==1.1.1         # via -r requirements/test.txt, jinja2
 mccabe==0.6.1             # via -r requirements/test.txt, pylint
-mock==4.0.2               # via -r requirements/test.txt
-mysqlclient==2.0.1        # via -r requirements/test.txt
-newrelic==5.20.1.150      # via -r requirements/test.txt, edx-django-utils
+mock==4.0.3               # via -r requirements/test.txt
+mysqlclient==2.0.3        # via -r requirements/test.txt
+newrelic==5.24.0.153      # via -r requirements/test.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/test.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 openpyxl==3.0.5           # via -r requirements/test.txt, tablib
-packaging==20.4           # via -r requirements/test.txt, pytest, tox
-pbr==5.5.0                # via -r requirements/test.txt, stevedore
-pillow==7.2.0             # via -r requirements/test.txt, wagtail
+packaging==20.8           # via -r requirements/test.txt, pytest, tox
+pbr==5.5.1                # via -r requirements/test.txt, stevedore
+pillow==8.1.0             # via -r requirements/test.txt, wagtail
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
-psutil==5.7.2             # via -r requirements/test.txt, edx-django-utils
-py==1.9.0                 # via -r requirements/test.txt, pytest, tox
+psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
+py==1.10.0                # via -r requirements/test.txt, pytest, tox
 pycodestyle==2.6.0        # via -r requirements/quality.in
 pycparser==2.20           # via -r requirements/test.txt, cffi
-pycryptodomex==3.9.8      # via -r requirements/test.txt, pyjwkest
+pycryptodomex==3.9.9      # via -r requirements/test.txt, pyjwkest
 pydocstyle==5.1.1         # via -r requirements/quality.in
 pyjwkest==1.4.2           # via -r requirements/test.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/test.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via -r requirements/test.txt, edx-lint
-pylint-django==2.0.11     # via -r requirements/test.txt, edx-lint
+pylint-django==2.3.0      # via -r requirements/test.txt, edx-lint
 pylint-plugin-utils==0.6  # via -r requirements/test.txt, pylint-celery, pylint-django
-pylint==2.4.4             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.11.0           # via -r requirements/test.txt, edx-opaque-keys
+pylint==2.6.0             # via -r requirements/test.txt, edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.11.2           # via -r requirements/test.txt, edx-opaque-keys
 pyparsing==2.4.7          # via -r requirements/test.txt, packaging
 pytest-cov==2.10.1        # via -r requirements/test.txt
-pytest-django==3.10.0     # via -r requirements/test.txt
-pytest==6.1.1             # via -r requirements/test.txt, pytest-cov, pytest-django
+pytest-django==4.1.0      # via -r requirements/test.txt
+pytest==6.2.1             # via -r requirements/test.txt, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/test.txt, edx-drf-extensions, faker
 python-slugify==4.0.1     # via -r requirements/test.txt, code-annotations
 python3-openid==3.2.0     # via -r requirements/test.txt, social-auth-core
-pytz==2020.1              # via -r requirements/test.txt, django, django-modelcluster, l18n
+pytz==2020.5              # via -r requirements/test.txt, django, django-modelcluster, l18n
 pyyaml==5.3.1             # via -r requirements/test.txt, code-annotations, edx-django-release-util
 requests-oauthlib==1.3.0  # via -r requirements/test.txt, social-auth-core
-requests==2.24.0          # via -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, wagtail
+requests==2.25.1          # via -r requirements/test.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, wagtail
 rest-condition==1.0.3     # via -r requirements/test.txt, edx-drf-extensions
 semantic-version==2.8.5   # via -r requirements/test.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/test.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/test.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, html5lib, l18n, packaging, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, tox, virtualenv
+six==1.15.0               # via -r requirements/test.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, html5lib, l18n, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, tox, virtualenv
 slumber==0.7.1            # via -r requirements/test.txt, edx-rest-api-client
 snowballstemmer==2.0.0    # via pydocstyle
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/test.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
-soupsieve==2.0.1          # via -r requirements/test.txt, beautifulsoup4
+social-auth-app-django==4.0.0  # via -r requirements/test.txt, edx-auth-backends
+social-auth-core==3.3.3   # via -r requirements/test.txt, edx-auth-backends, social-auth-app-django
+soupsieve==2.1            # via -r requirements/test.txt, beautifulsoup4
 sqlparse==0.4.1           # via -r requirements/test.txt, django
-stevedore==3.2.2          # via -r requirements/test.txt, code-annotations, edx-django-utils, edx-opaque-keys
-tablib[xls,xlsx]==2.0.0   # via -r requirements/test.txt, wagtail
+stevedore==3.3.0          # via -r requirements/test.txt, code-annotations, edx-django-utils, edx-opaque-keys
+tablib[xls,xlsx]==3.0.0   # via -r requirements/test.txt, wagtail
 text-unidecode==1.3       # via -r requirements/test.txt, faker, python-slugify
-toml==0.10.1              # via -r requirements/test.txt, pytest, tox
+toml==0.10.2              # via -r requirements/test.txt, pylint, pytest, tox
 tox==3.20.1               # via -r requirements/test.txt
-unidecode==1.1.1          # via -r requirements/test.txt, wagtail
+unidecode==1.1.2          # via -r requirements/test.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
-urllib3==1.25.10          # via -r requirements/test.txt, requests
-virtualenv==20.0.34       # via -r requirements/test.txt, tox
-wagtail==2.10.2           # via -r requirements/test.txt
+urllib3==1.26.2           # via -r requirements/test.txt, requests
+virtualenv==20.2.2        # via -r requirements/test.txt, tox
+wagtail==2.11.3           # via -r requirements/test.txt
 webencodings==0.5.1       # via -r requirements/test.txt, html5lib
 willow==1.4               # via -r requirements/test.txt, wagtail
-wrapt==1.11.2             # via -r requirements/test.txt, astroid
-xlrd==1.2.0               # via -r requirements/test.txt, tablib
+wrapt==1.12.1             # via -r requirements/test.txt, astroid
+xlrd==2.0.1               # via -r requirements/test.txt, tablib
 xlsxwriter==1.3.7         # via -r requirements/test.txt, wagtail
 xlwt==1.3.0               # via -r requirements/test.txt, tablib
-zipp==3.3.0               # via -r requirements/test.txt
+zipp==3.4.0               # via -r requirements/test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-anyascii==0.1.7           # via -r requirements/test.txt, wagtail
 appdirs==1.4.4            # via -r requirements/test.txt, virtualenv
 astroid==2.4.2            # via -r requirements/test.txt, pylint, pylint-celery
 attrs==20.3.0             # via -r requirements/test.txt, pytest
@@ -68,7 +67,7 @@ openapi-codec==1.3.2      # via -r requirements/test.txt, django-rest-swagger
 openpyxl==3.0.5           # via -r requirements/test.txt, tablib
 packaging==20.8           # via -r requirements/test.txt, pytest, tox
 pbr==5.5.1                # via -r requirements/test.txt, stevedore
-pillow==8.1.0             # via -r requirements/test.txt, wagtail
+pillow==7.2.0             # via -r requirements/test.txt, wagtail
 pluggy==0.13.1            # via -r requirements/test.txt, pytest, tox
 psutil==5.8.0             # via -r requirements/test.txt, edx-django-utils
 py==1.10.0                # via -r requirements/test.txt, pytest, tox
@@ -113,7 +112,7 @@ unidecode==1.1.2          # via -r requirements/test.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/test.txt, coreapi
 urllib3==1.26.2           # via -r requirements/test.txt, requests
 virtualenv==20.2.2        # via -r requirements/test.txt, tox
-wagtail==2.11.3           # via -r requirements/test.txt
+wagtail==2.10.2           # via -r requirements/test.txt
 webencodings==0.5.1       # via -r requirements/test.txt, html5lib
 willow==1.4               # via -r requirements/test.txt, wagtail
 wrapt==1.12.1             # via -r requirements/test.txt, astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,6 @@
 #
 #    make upgrade
 #
-anyascii==0.1.7           # via -r requirements/base.txt, wagtail
 appdirs==1.4.4            # via virtualenv
 astroid==2.4.2            # via pylint, pylint-celery
 attrs==20.3.0             # via pytest
@@ -67,7 +66,7 @@ openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 openpyxl==3.0.5           # via -r requirements/base.txt, tablib
 packaging==20.8           # via pytest, tox
 pbr==5.5.1                # via -r requirements/base.txt, stevedore
-pillow==8.1.0             # via -r requirements/base.txt, wagtail
+pillow==7.2.0             # via -r requirements/base.txt, wagtail
 pluggy==0.13.1            # via pytest, tox
 psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
 py==1.10.0                # via pytest, tox
@@ -109,7 +108,7 @@ unidecode==1.1.2          # via -r requirements/base.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.26.2           # via -r requirements/base.txt, requests
 virtualenv==20.2.2        # via tox
-wagtail==2.11.3           # via -r requirements/base.txt
+wagtail==2.10.2           # via -c requirements/constraints.txt, -r requirements/base.txt
 webencodings==0.5.1       # via -r requirements/base.txt, html5lib
 willow==1.4               # via -r requirements/base.txt, wagtail
 wrapt==1.12.1             # via astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,114 +4,116 @@
 #
 #    make upgrade
 #
+anyascii==0.1.7           # via -r requirements/base.txt, wagtail
 appdirs==1.4.4            # via virtualenv
-astroid==2.3.3            # via pylint, pylint-celery
-attrs==20.2.0             # via pytest
+astroid==2.4.2            # via pylint, pylint-celery
+attrs==20.3.0             # via pytest
 beautifulsoup4==4.8.2     # via -r requirements/base.txt, wagtail
-certifi==2020.6.20        # via -r requirements/base.txt, requests
-cffi==1.14.3              # via -r requirements/base.txt, cryptography
-chardet==3.0.4            # via -r requirements/base.txt, requests
+certifi==2020.12.5        # via -r requirements/base.txt, requests
+cffi==1.14.4              # via -r requirements/base.txt, cryptography
+chardet==4.0.0            # via -r requirements/base.txt, requests
 click-log==0.3.2          # via edx-lint
 click==7.1.2              # via click-log, code-annotations, edx-lint
-code-annotations==0.9.0   # via -r requirements/test.in
+code-annotations==0.10.2  # via -r requirements/test.in
 coreapi==2.3.3            # via -r requirements/base.txt, django-rest-swagger, openapi-codec
 coreschema==0.0.4         # via -r requirements/base.txt, coreapi
-coverage==5.3             # via -r requirements/test.in, pytest-cov
-cryptography==3.1.1       # via -r requirements/base.txt, pyjwt
+coverage==5.3.1           # via -r requirements/test.in, pytest-cov
+cryptography==3.3.1       # via -r requirements/base.txt, pyjwt, social-auth-core
 defusedxml==0.6.0         # via -r requirements/base.txt, python3-openid, social-auth-core
 distlib==0.3.1            # via virtualenv
-django-cors-headers==3.5.0  # via -r requirements/base.txt
-django-dynamic-fixture==3.1.0  # via -r requirements/test.in
-django-extensions==3.0.9  # via -r requirements/base.txt
+django-cors-headers==3.6.0  # via -r requirements/base.txt
+django-crum==0.7.9        # via -r requirements/base.txt, edx-django-utils
+django-dynamic-fixture==3.1.1  # via -r requirements/test.in
+django-extensions==3.1.0  # via -r requirements/base.txt
 django-filter==2.4.0      # via -r requirements/base.txt, wagtail
 django-modelcluster==5.1  # via -r requirements/base.txt, wagtail
 django-rest-swagger==2.2.0  # via -r requirements/base.txt
-django-storages==1.10.1   # via -r requirements/base.txt
+django-storages==1.11.1   # via -r requirements/base.txt
 django-taggit==1.3.0      # via -r requirements/base.txt, wagtail
 django-treebeard==4.3.1   # via -r requirements/base.txt, wagtail
 django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-drf-extensions
-djangorestframework==3.12.1  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
+djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/base.txt, wagtail
-drf-jwt==1.17.2           # via -r requirements/base.txt, edx-drf-extensions
+drf-jwt==1.17.3           # via -r requirements/base.txt, edx-drf-extensions
 edx-auth-backends==3.1.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
-edx-django-utils==3.8.0   # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
+edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/base.txt
-edx-lint==1.5.2           # via -r requirements/test.in
+edx-lint==1.6             # via -r requirements/test.in
 edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -c requirements/constraints.txt, -r requirements/base.txt
 et-xmlfile==1.0.1         # via -r requirements/base.txt, openpyxl
-factory-boy==3.1.0        # via -r requirements/test.in
-faker==4.9.0              # via -r requirements/test.in, factory-boy
+factory-boy==3.2.0        # via -r requirements/test.in
+faker==5.4.0              # via -r requirements/test.in, factory-boy
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 html5lib==1.1             # via -r requirements/base.txt, wagtail
 idna==2.10                # via -r requirements/base.txt, requests
-inflect==4.1.0            # via -r requirements/base.txt
-iniconfig==1.0.1          # via pytest
-isort==4.3.21             # via pylint
+inflect==5.0.2            # via -r requirements/base.txt
+iniconfig==1.1.1          # via pytest
+isort==5.7.0              # via pylint
 itypes==1.2.0             # via -r requirements/base.txt, coreapi
 jdcal==1.4.1              # via -r requirements/base.txt, openpyxl
 jinja2==2.11.2            # via -r requirements/base.txt, code-annotations, coreschema
-l18n==2018.5              # via -r requirements/base.txt, wagtail
+l18n==2020.6.1            # via -r requirements/base.txt, wagtail
 lazy-object-proxy==1.4.3  # via astroid
 markupsafe==1.1.1         # via -r requirements/base.txt, jinja2
 mccabe==0.6.1             # via pylint
-mock==4.0.2               # via -r requirements/base.txt, -r requirements/test.in
-mysqlclient==2.0.1        # via -r requirements/base.txt
-newrelic==5.20.1.150      # via -r requirements/base.txt, edx-django-utils
+mock==4.0.3               # via -r requirements/base.txt, -r requirements/test.in
+mysqlclient==2.0.3        # via -r requirements/base.txt
+newrelic==5.24.0.153      # via -r requirements/base.txt, edx-django-utils
 oauthlib==3.1.0           # via -r requirements/base.txt, requests-oauthlib, social-auth-core
 openapi-codec==1.3.2      # via -r requirements/base.txt, django-rest-swagger
 openpyxl==3.0.5           # via -r requirements/base.txt, tablib
-packaging==20.4           # via pytest, tox
-pbr==5.5.0                # via -r requirements/base.txt, stevedore
-pillow==7.2.0             # via -r requirements/base.txt, wagtail
+packaging==20.8           # via pytest, tox
+pbr==5.5.1                # via -r requirements/base.txt, stevedore
+pillow==8.1.0             # via -r requirements/base.txt, wagtail
 pluggy==0.13.1            # via pytest, tox
-psutil==5.7.2             # via -r requirements/base.txt, edx-django-utils
-py==1.9.0                 # via pytest, tox
+psutil==5.8.0             # via -r requirements/base.txt, edx-django-utils
+py==1.10.0                # via pytest, tox
 pycparser==2.20           # via -r requirements/base.txt, cffi
-pycryptodomex==3.9.8      # via -r requirements/base.txt, pyjwkest
+pycryptodomex==3.9.9      # via -r requirements/base.txt, pyjwkest
 pyjwkest==1.4.2           # via -r requirements/base.txt, edx-drf-extensions
 pyjwt[crypto]==1.7.1      # via -r requirements/base.txt, drf-jwt, edx-auth-backends, edx-rest-api-client, social-auth-core
 pylint-celery==0.3        # via edx-lint
-pylint-django==2.0.11     # via edx-lint
+pylint-django==2.3.0      # via edx-lint
 pylint-plugin-utils==0.6  # via pylint-celery, pylint-django
-pylint==2.4.4             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
-pymongo==3.11.0           # via -r requirements/base.txt, edx-opaque-keys
+pylint==2.6.0             # via edx-lint, pylint-celery, pylint-django, pylint-plugin-utils
+pymongo==3.11.2           # via -r requirements/base.txt, edx-opaque-keys
 pyparsing==2.4.7          # via packaging
 pytest-cov==2.10.1        # via -r requirements/test.in
-pytest-django==3.10.0     # via -r requirements/test.in
-pytest==6.1.1             # via -r requirements/test.in, pytest-cov, pytest-django
+pytest-django==4.1.0      # via -r requirements/test.in
+pytest==6.2.1             # via -r requirements/test.in, pytest-cov, pytest-django
 python-dateutil==2.8.1    # via -r requirements/base.txt, edx-drf-extensions, faker
 python-slugify==4.0.1     # via code-annotations
 python3-openid==3.2.0     # via -r requirements/base.txt, social-auth-core
-pytz==2020.1              # via -r requirements/base.txt, django, django-modelcluster, l18n
+pytz==2020.5              # via -r requirements/base.txt, django, django-modelcluster, l18n
 pyyaml==5.3.1             # via -r requirements/base.txt, code-annotations, edx-django-release-util
 requests-oauthlib==1.3.0  # via -r requirements/base.txt, social-auth-core
-requests==2.24.0          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, wagtail
+requests==2.25.1          # via -r requirements/base.txt, coreapi, edx-drf-extensions, edx-rest-api-client, pyjwkest, requests-oauthlib, slumber, social-auth-core, wagtail
 rest-condition==1.0.3     # via -r requirements/base.txt, edx-drf-extensions
 semantic-version==2.8.5   # via -r requirements/base.txt, edx-drf-extensions
 simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
-six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, html5lib, l18n, packaging, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, tox, virtualenv
+six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, html5lib, l18n, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, tox, virtualenv
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
-git+https://github.com/python-social-auth/social-app-django.git@c00d23c2b45c3317bd35b15ad1b959338689cef8#egg=social-auth-app-django  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.2.0   # via -c requirements/constraints.txt, -r requirements/base.txt, edx-auth-backends, social-auth-app-django
-soupsieve==2.0.1          # via -r requirements/base.txt, beautifulsoup4
+social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
+social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+soupsieve==2.1            # via -r requirements/base.txt, beautifulsoup4
 sqlparse==0.4.1           # via -r requirements/base.txt, django
-stevedore==3.2.2          # via -r requirements/base.txt, code-annotations, edx-django-utils, edx-opaque-keys
-tablib[xls,xlsx]==2.0.0   # via -r requirements/base.txt, wagtail
+stevedore==3.3.0          # via -r requirements/base.txt, code-annotations, edx-django-utils, edx-opaque-keys
+tablib[xls,xlsx]==3.0.0   # via -r requirements/base.txt, wagtail
 text-unidecode==1.3       # via faker, python-slugify
-toml==0.10.1              # via pytest, tox
+toml==0.10.2              # via pylint, pytest, tox
 tox==3.20.1               # via -r requirements/test.in
-unidecode==1.1.1          # via -r requirements/base.txt, wagtail
+unidecode==1.1.2          # via -r requirements/base.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
-urllib3==1.25.10          # via -r requirements/base.txt, requests
-virtualenv==20.0.34       # via tox
-wagtail==2.10.2           # via -r requirements/base.txt
+urllib3==1.26.2           # via -r requirements/base.txt, requests
+virtualenv==20.2.2        # via tox
+wagtail==2.11.3           # via -r requirements/base.txt
 webencodings==0.5.1       # via -r requirements/base.txt, html5lib
 willow==1.4               # via -r requirements/base.txt, wagtail
-wrapt==1.11.2             # via astroid
-xlrd==1.2.0               # via -r requirements/base.txt, tablib
+wrapt==1.12.1             # via astroid
+xlrd==2.0.1               # via -r requirements/base.txt, tablib
 xlsxwriter==1.3.7         # via -r requirements/base.txt, wagtail
 xlwt==1.3.0               # via -r requirements/base.txt, tablib
-zipp==3.3.0               # via -r requirements/base.txt
+zipp==3.4.0               # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -34,7 +34,7 @@ django-waffle==2.0.0      # via -r requirements/base.txt, edx-django-utils, edx-
 djangorestframework==3.12.2  # via -r requirements/base.txt, django-rest-swagger, drf-jwt, edx-drf-extensions, rest-condition, wagtail
 draftjs-exporter==2.1.7   # via -r requirements/base.txt, wagtail
 drf-jwt==1.17.3           # via -r requirements/base.txt, edx-drf-extensions
-edx-auth-backends==3.1.0  # via -r requirements/base.txt
+edx-auth-backends==3.3.0  # via -r requirements/base.txt
 edx-django-release-util==0.4.4  # via -r requirements/base.txt
 edx-django-utils==3.13.0  # via -r requirements/base.txt, edx-drf-extensions, edx-rest-api-client
 edx-drf-extensions==6.2.0  # via -r requirements/base.txt
@@ -43,7 +43,7 @@ edx-opaque-keys==2.1.1    # via -r requirements/base.txt, edx-drf-extensions
 edx_rest_api_client==4.0.1  # via -c requirements/constraints.txt, -r requirements/base.txt
 et-xmlfile==1.0.1         # via -r requirements/base.txt, openpyxl
 factory-boy==3.2.0        # via -r requirements/test.in
-faker==5.4.0              # via -r requirements/test.in, factory-boy
+faker==5.5.0              # via -r requirements/test.in, factory-boy
 filelock==3.0.12          # via tox, virtualenv
 future==0.18.2            # via -r requirements/base.txt, pyjwkest
 html5lib==1.1             # via -r requirements/base.txt, wagtail
@@ -96,18 +96,18 @@ simplejson==3.17.2        # via -r requirements/base.txt, django-rest-swagger
 six==1.15.0               # via -r requirements/base.txt, astroid, cryptography, django-dynamic-fixture, edx-auth-backends, edx-django-release-util, edx-drf-extensions, edx-lint, edx-opaque-keys, html5lib, l18n, pyjwkest, python-dateutil, social-auth-app-django, social-auth-core, tox, virtualenv
 slumber==0.7.1            # via -r requirements/base.txt, edx-rest-api-client
 social-auth-app-django==4.0.0  # via -r requirements/base.txt, edx-auth-backends
-social-auth-core==3.3.3   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
+social-auth-core==4.0.2   # via -r requirements/base.txt, edx-auth-backends, social-auth-app-django
 soupsieve==2.1            # via -r requirements/base.txt, beautifulsoup4
 sqlparse==0.4.1           # via -r requirements/base.txt, django
 stevedore==3.3.0          # via -r requirements/base.txt, code-annotations, edx-django-utils, edx-opaque-keys
 tablib[xls,xlsx]==3.0.0   # via -r requirements/base.txt, wagtail
 text-unidecode==1.3       # via faker, python-slugify
 toml==0.10.2              # via pylint, pytest, tox
-tox==3.20.1               # via -r requirements/test.in
+tox==3.21.0               # via -r requirements/test.in
 unidecode==1.1.2          # via -r requirements/base.txt, wagtail
 uritemplate==3.0.1        # via -r requirements/base.txt, coreapi
 urllib3==1.26.2           # via -r requirements/base.txt, requests
-virtualenv==20.2.2        # via tox
+virtualenv==20.3.0        # via tox
 wagtail==2.10.2           # via -c requirements/constraints.txt, -r requirements/base.txt
 webencodings==0.5.1       # via -r requirements/base.txt, html5lib
 willow==1.4               # via -r requirements/base.txt, wagtail


### PR DESCRIPTION
The bug mentioned on [ARCHBOM-1078](https://openedx.atlassian.net/browse/ARCHBOM-1078) is fixed in `social-auth-core==3.3.3`, See [this comment](https://openedx.atlassian.net/browse/BOM-2094?focusedCommentId=514498) for details, now we are unpinning it wherever it was previously pinned due to that bug.
Relevant JIRA : https://openedx.atlassian.net/browse/BOM-2189