### PR TITLE
chore: upgrade django-dynamic-fixture version

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -121,7 +121,7 @@ django-crum==0.7.9
     #   edx-django-utils
 django-debug-toolbar==3.2.2
     # via -r requirements/dev.in
-django-dynamic-fixture==3.1.1
+django-dynamic-fixture==3.1.2
     # via -r requirements/quality.txt
 django-extensions==3.1.3
     # via -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -115,7 +115,7 @@ django-crum==0.7.9
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-django-dynamic-fixture==3.1.1
+django-dynamic-fixture==3.1.2
     # via -r requirements/test.txt
 django-extensions==3.1.3
     # via -r requirements/test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -109,7 +109,7 @@ django-crum==0.7.9
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-django-dynamic-fixture==3.1.1
+django-dynamic-fixture==3.1.2
     # via -r requirements/test.txt
 django-extensions==3.1.3
     # via -r requirements/test.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -98,7 +98,7 @@ django-crum==0.7.9
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-django-dynamic-fixture==3.1.1
+django-dynamic-fixture==3.1.2
     # via -r requirements/test.in
 django-extensions==3.1.3
     # via -r requirements/base.txt


### PR DESCRIPTION
## Description

New version of django-dynamic-fixture was introduced to support Django3.2

Upgrade issue: https://github.com/edx/upgrades/issues/26
