### PR TITLE
remove no longer needed constraints

### DIFF
--- a/.annotation_safe_list.yml
+++ b/.annotation_safe_list.yml
@@ -105,3 +105,9 @@ wagtailcore.WorkflowTask:
   ".. no_pii:": "This model has no PII"
 wagtailcore.Locale:
   ".. no_pii:": "This model has no PII"
+wagtailcore.ModelLogEntry:
+  ".. no_pii:": "This model has no PII"
+wagtailsearch.IndexEntry:
+  ".. no_pii:": "This model has no PII"
+wagtailsearch.SQLiteFTSIndexEntry:
+  ".. no_pii:": "This model has no PII"

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -57,13 +57,13 @@ django-crum==0.7.9
     # via edx-django-utils
 django-extensions==3.1.5
     # via -r requirements/base.in
-django-filter==2.4.0
+django-filter==21.1
     # via wagtail
 django-modelcluster==5.3
     # via wagtail
 django-storages==1.12.3
     # via -r requirements/base.in
-django-taggit==1.5.1
+django-taggit==2.1.0
     # via wagtail
 django-treebeard==4.5.1
     # via wagtail
@@ -143,7 +143,7 @@ packaging==21.3
     # via drf-yasg
 pbr==5.8.1
     # via stevedore
-pillow==8.4.0
+pillow==9.1.0
     # via wagtail
 psutil==5.9.0
     # via edx-django-utils
@@ -235,17 +235,15 @@ uritemplate==4.1.1
     #   drf-yasg
 urllib3==1.26.9
     # via requests
-wagtail==2.13.4
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.in
+wagtail==2.16.2
+    # via -r requirements/base.in
 webencodings==0.5.1
     # via html5lib
 willow==1.4.1
     # via wagtail
 xlrd==2.0.1
     # via tablib
-xlsxwriter==1.4.5
+xlsxwriter==3.0.3
     # via wagtail
 xlwt==1.3.0
     # via tablib

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -15,14 +15,4 @@
 # We need to stay on LTS version
 Django<3.3
 
-
 edx_rest_api_client==4.0.1      # versions>4.0.1 have backward incompatible changes in timeout handling
-
-
-# greater versions incompatible with Django 2.x
-wagtail==2.13.4
-
-# diff-cover latest requires (pluggy>=0.13.1,<0.14.0)
-# which conflicts with pytest(pluggy>=0.12,<2.0.0) and tox(pluggy>0.12) both of these fetch pluggy==1.0.0
-# but diff-cover latest has a pin (pluggy<1.0.0a1)
-diff-cover<6.2.2

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -81,10 +81,8 @@ defusedxml==0.7.1
     #   -r requirements/quality.txt
     #   python3-openid
     #   social-auth-core
-diff-cover==6.2.1
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/dev.in
+diff-cover==6.5.0
+    # via -r requirements/dev.in
 dill==0.3.4
     # via
     #   -r requirements/quality.txt
@@ -128,7 +126,7 @@ django-dynamic-fixture==3.1.2
     # via -r requirements/quality.txt
 django-extensions==3.1.5
     # via -r requirements/quality.txt
-django-filter==2.4.0
+django-filter==21.1
     # via
     #   -r requirements/quality.txt
     #   wagtail
@@ -138,7 +136,7 @@ django-modelcluster==5.3
     #   wagtail
 django-storages==1.12.3
     # via -r requirements/quality.txt
-django-taggit==1.5.1
+django-taggit==2.1.0
     # via
     #   -r requirements/quality.txt
     #   wagtail
@@ -224,9 +222,7 @@ idna==3.3
     #   -r requirements/quality.txt
     #   requests
 inflect==5.5.2
-    # via
-    #   -r requirements/quality.txt
-    #   jinja2-pluralize
+    # via -r requirements/quality.txt
 inflection==0.5.1
     # via
     #   -r requirements/quality.txt
@@ -249,9 +245,6 @@ jinja2==3.1.1
     #   code-annotations
     #   coreschema
     #   diff-cover
-    #   jinja2-pluralize
-jinja2-pluralize==0.3.0
-    # via diff-cover
 l18n==2021.3
     # via
     #   -r requirements/quality.txt
@@ -301,7 +294,7 @@ pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-pillow==8.4.0
+pillow==9.1.0
     # via
     #   -r requirements/quality.txt
     #   wagtail
@@ -536,10 +529,8 @@ virtualenv==20.14.1
     # via
     #   -r requirements/quality.txt
     #   tox
-wagtail==2.13.4
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/quality.txt
+wagtail==2.16.2
+    # via -r requirements/quality.txt
 webencodings==0.5.1
     # via
     #   -r requirements/quality.txt
@@ -560,7 +551,7 @@ xlrd==2.0.1
     # via
     #   -r requirements/quality.txt
     #   tablib
-xlsxwriter==1.4.5
+xlsxwriter==3.0.3
     # via
     #   -r requirements/quality.txt
     #   wagtail

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,7 +12,7 @@ asgiref==3.5.0
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.11.2
+astroid==2.11.3
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -202,7 +202,7 @@ et-xmlfile==1.1.0
     #   openpyxl
 factory-boy==3.2.1
     # via -r requirements/quality.txt
-faker==13.3.4
+faker==13.4.0
     # via
     #   -r requirements/quality.txt
     #   factory-boy
@@ -307,7 +307,7 @@ pillow==8.4.0
     #   wagtail
 pip-tools==6.6.0
     # via -r requirements/pip-tools.txt
-platformdirs==2.5.1
+platformdirs==2.5.2
     # via
     #   -r requirements/quality.txt
     #   pylint
@@ -355,7 +355,7 @@ pyjwt[crypto]==2.3.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.13.5
+pylint==2.13.7
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -518,7 +518,7 @@ tomli==2.0.1
     #   pytest
 tox==3.25.0
     # via -r requirements/quality.txt
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via
     #   -r requirements/quality.txt
     #   astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -14,7 +14,7 @@ asgiref==3.5.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.11.2
+astroid==2.11.3
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -23,7 +23,7 @@ attrs==21.4.0
     # via
     #   -r requirements/test.txt
     #   pytest
-babel==2.9.1
+babel==2.10.1
     # via sphinx
 beautifulsoup4==4.9.3
     # via
@@ -200,7 +200,7 @@ et-xmlfile==1.1.0
     #   openpyxl
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==13.3.4
+faker==13.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -297,7 +297,7 @@ pillow==8.4.0
     # via
     #   -r requirements/test.txt
     #   wagtail
-platformdirs==2.5.1
+platformdirs==2.5.2
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -341,7 +341,7 @@ pyjwt[crypto]==2.3.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.13.5
+pylint==2.13.7
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -404,7 +404,7 @@ pyyaml==6.0
     #   -r requirements/test.txt
     #   code-annotations
     #   edx-django-release-util
-readme-renderer==34.0
+readme-renderer==35.0
     # via -r requirements/doc.in
 requests==2.27.1
     # via
@@ -523,7 +523,7 @@ tomli==2.0.1
     #   pytest
 tox==3.25.0
     # via -r requirements/test.txt
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via
     #   -r requirements/test.txt
     #   astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -120,7 +120,7 @@ django-dynamic-fixture==3.1.2
     # via -r requirements/test.txt
 django-extensions==3.1.5
     # via -r requirements/test.txt
-django-filter==2.4.0
+django-filter==21.1
     # via
     #   -r requirements/test.txt
     #   wagtail
@@ -130,7 +130,7 @@ django-modelcluster==5.3
     #   wagtail
 django-storages==1.12.3
     # via -r requirements/test.txt
-django-taggit==1.5.1
+django-taggit==2.1.0
     # via
     #   -r requirements/test.txt
     #   wagtail
@@ -293,7 +293,7 @@ pbr==5.8.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-pillow==8.4.0
+pillow==9.1.0
     # via
     #   -r requirements/test.txt
     #   wagtail
@@ -541,7 +541,7 @@ virtualenv==20.14.1
     # via
     #   -r requirements/test.txt
     #   tox
-wagtail==2.13.4
+wagtail==2.16.2
     # via -r requirements/test.txt
 webencodings==0.5.1
     # via
@@ -560,7 +560,7 @@ xlrd==2.0.1
     # via
     #   -r requirements/test.txt
     #   tablib
-xlsxwriter==1.4.5
+xlsxwriter==3.0.3
     # via
     #   -r requirements/test.txt
     #   wagtail

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -16,9 +16,9 @@ beautifulsoup4==4.9.3
     # via
     #   -r requirements/base.txt
     #   wagtail
-boto3==1.21.42
+boto3==1.21.45
     # via -r requirements/production.in
-botocore==1.24.42
+botocore==1.24.45
     # via
     #   boto3
     #   s3transfer

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -80,7 +80,7 @@ django-crum==0.7.9
     #   edx-django-utils
 django-extensions==3.1.5
     # via -r requirements/base.txt
-django-filter==2.4.0
+django-filter==21.1
     # via
     #   -r requirements/base.txt
     #   wagtail
@@ -90,7 +90,7 @@ django-modelcluster==5.3
     #   wagtail
 django-storages==1.12.3
     # via -r requirements/base.txt
-django-taggit==1.5.1
+django-taggit==2.1.0
     # via
     #   -r requirements/base.txt
     #   wagtail
@@ -215,7 +215,7 @@ pbr==5.8.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-pillow==8.4.0
+pillow==9.1.0
     # via
     #   -r requirements/base.txt
     #   wagtail
@@ -358,7 +358,7 @@ urllib3==1.26.9
     #   -r requirements/base.txt
     #   botocore
     #   requests
-wagtail==2.13.4
+wagtail==2.16.2
     # via -r requirements/base.txt
 webencodings==0.5.1
     # via
@@ -372,7 +372,7 @@ xlrd==2.0.1
     # via
     #   -r requirements/base.txt
     #   tablib
-xlsxwriter==1.4.5
+xlsxwriter==3.0.3
     # via
     #   -r requirements/base.txt
     #   wagtail

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -114,7 +114,7 @@ django-dynamic-fixture==3.1.2
     # via -r requirements/test.txt
 django-extensions==3.1.5
     # via -r requirements/test.txt
-django-filter==2.4.0
+django-filter==21.1
     # via
     #   -r requirements/test.txt
     #   wagtail
@@ -124,7 +124,7 @@ django-modelcluster==5.3
     #   wagtail
 django-storages==1.12.3
     # via -r requirements/test.txt
-django-taggit==1.5.1
+django-taggit==2.1.0
     # via
     #   -r requirements/test.txt
     #   wagtail
@@ -274,7 +274,7 @@ pbr==5.8.1
     # via
     #   -r requirements/test.txt
     #   stevedore
-pillow==8.4.0
+pillow==9.1.0
     # via
     #   -r requirements/test.txt
     #   wagtail
@@ -496,7 +496,7 @@ virtualenv==20.14.1
     # via
     #   -r requirements/test.txt
     #   tox
-wagtail==2.13.4
+wagtail==2.16.2
     # via -r requirements/test.txt
 webencodings==0.5.1
     # via
@@ -514,7 +514,7 @@ xlrd==2.0.1
     # via
     #   -r requirements/test.txt
     #   tablib
-xlsxwriter==1.4.5
+xlsxwriter==3.0.3
     # via
     #   -r requirements/test.txt
     #   wagtail

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,7 +12,7 @@ asgiref==3.5.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.11.2
+astroid==2.11.3
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -186,7 +186,7 @@ et-xmlfile==1.1.0
     #   openpyxl
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==13.3.4
+faker==13.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -278,7 +278,7 @@ pillow==8.4.0
     # via
     #   -r requirements/test.txt
     #   wagtail
-platformdirs==2.5.1
+platformdirs==2.5.2
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -321,7 +321,7 @@ pyjwt[crypto]==2.3.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.13.5
+pylint==2.13.7
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -478,7 +478,7 @@ tomli==2.0.1
     #   pytest
 tox==3.25.0
     # via -r requirements/test.txt
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via
     #   -r requirements/test.txt
     #   astroid

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -105,7 +105,7 @@ django-dynamic-fixture==3.1.2
     # via -r requirements/test.in
 django-extensions==3.1.5
     # via -r requirements/base.txt
-django-filter==2.4.0
+django-filter==21.1
     # via
     #   -r requirements/base.txt
     #   wagtail
@@ -115,7 +115,7 @@ django-modelcluster==5.3
     #   wagtail
 django-storages==1.12.3
     # via -r requirements/base.txt
-django-taggit==1.5.1
+django-taggit==2.1.0
     # via
     #   -r requirements/base.txt
     #   wagtail
@@ -257,7 +257,7 @@ pbr==5.8.1
     # via
     #   -r requirements/base.txt
     #   stevedore
-pillow==8.4.0
+pillow==9.1.0
     # via
     #   -r requirements/base.txt
     #   wagtail
@@ -454,10 +454,8 @@ urllib3==1.26.9
     #   requests
 virtualenv==20.14.1
     # via tox
-wagtail==2.13.4
-    # via
-    #   -c requirements/constraints.txt
-    #   -r requirements/base.txt
+wagtail==2.16.2
+    # via -r requirements/base.txt
 webencodings==0.5.1
     # via
     #   -r requirements/base.txt
@@ -472,7 +470,7 @@ xlrd==2.0.1
     # via
     #   -r requirements/base.txt
     #   tablib
-xlsxwriter==1.4.5
+xlsxwriter==3.0.3
     # via
     #   -r requirements/base.txt
     #   wagtail

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,7 +12,7 @@ asgiref==3.5.0
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.11.2
+astroid==2.11.3
     # via
     #   pylint
     #   pylint-celery
@@ -177,7 +177,7 @@ et-xmlfile==1.1.0
     #   openpyxl
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==13.3.4
+faker==13.4.0
     # via
     #   -r requirements/test.in
     #   factory-boy
@@ -261,7 +261,7 @@ pillow==8.4.0
     # via
     #   -r requirements/base.txt
     #   wagtail
-platformdirs==2.5.1
+platformdirs==2.5.2
     # via
     #   pylint
     #   virtualenv
@@ -297,7 +297,7 @@ pyjwt[crypto]==2.3.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
-pylint==2.13.5
+pylint==2.13.7
     # via
     #   edx-lint
     #   pylint-celery
@@ -439,7 +439,7 @@ tomli==2.0.1
     #   pytest
 tox==3.25.0
     # via -r requirements/test.in
-typing-extensions==4.1.1
+typing-extensions==4.2.0
     # via
     #   astroid
     #   pylint


### PR DESCRIPTION
wagtail pin was for django 2.2 which we no longer support.

Upgrading wagtail meant we had to update the PII annotations a bit.

diff_cover was dealing with an unfortunate version pin in its own dependencies which is now gone
