### PR TITLE
fix: Install pip and pip-tools after upgrading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,8 @@ upgrade: $(COMMON_CONSTRAINTS_TXT)	## update the requirements/*.txt files with t
 	# Make sure to compile files after any other files they include!
 	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --upgrade -o requirements/test.txt requirements/test.in
 	pip-compile --upgrade -o requirements/doc.txt requirements/doc.in


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this [PR](https://github.com/openedx/edx-repo-health/pull/271) for new check added in edx-repo-health. 
JIRA: https://2u-internal.atlassian.net/browse/BOM-3426