### PR TITLE
build: add cookie monitoring middleware

### DIFF
--- a/designer/settings/base.py
+++ b/designer/settings/base.py
@@ -66,6 +66,7 @@ INSTALLED_APPS += PROJECT_APPS
 INSTALLED_APPS += WAGTAIL_APPS
 
 MIDDLEWARE = (
+    'edx_django_utils.monitoring.CookieMonitoringMiddleware',
     'edx_django_utils.monitoring.DeploymentMonitoringMiddleware',
     'waffle.middleware.WaffleMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',


### PR DESCRIPTION
**Issue:** [BOM-3449](https://2u-internal.atlassian.net/browse/BOM-3449)

### Description
- Add `CookieMonitoringMiddleware` in settings.