### PR TITLE
fix: upgrade pip-tools to fix bug in versions 6.6.0 and 6.6.1

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -298,7 +298,7 @@ pillow==9.1.0
     # via
     #   -r requirements/quality.txt
     #   wagtail
-pip-tools==6.6.0
+pip-tools==6.6.2
     # via -r requirements/pip-tools.txt
 platformdirs==2.5.2
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,7 +8,7 @@ click==8.1.2
     # via pip-tools
 pep517==0.12.0
     # via pip-tools
-pip-tools==6.6.0
+pip-tools==6.6.2
     # via -r requirements/pip-tools.in
 tomli==2.0.1
     # via pep517


### PR DESCRIPTION
This commit upgrades the version of pip-tools used in this repository from `6.6.0` to `6.6.2`.

In version `6.6.0` of `pip-tools`, there is a bug that is preventing `pip-tools` from working. This is breaking the Python requirements update GitHub action in this repository.

The error is `ImportError: cannot import name 'BAR_TYPES' from 'pip._internal.cli.progress_bars'`. The error was reported [here](https://github.com/jazzband/pip-tools/issues/1617). The fix to this bug was released in version `6.6.2` of `pip-tools`. See the comment [here](https://github.com/jazzband/pip-tools/issues/1617#issuecomment-1126245586).

Version `6.6.1` of `pip-tools` also has a bug, which is fixed in version `6.6.2`. I observed this issue breaking the Python requirements update GitHub action in another repository, so I have upgrade the version straight to `6.6.2`. The issue in version `6.6.1` was reported [here](https://github.com/jazzband/pip-tools/pull/1624).