### PR TITLE
-t flag added in pull translation command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,7 +130,7 @@ compile_translations:
 
 fake_translations: extract_translations dummy_translations compile_translations
 
-pull_translations:
+pull_translations: ## pull translations from Transifex
 	tx pull -t -af --mode reviewed
 
 push_translations:

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ compile_translations:
 fake_translations: extract_translations dummy_translations compile_translations
 
 pull_translations:
-	tx pull -af --mode reviewed
+	tx pull -t -af --mode reviewed
 
 push_translations:
 	tx push -s


### PR DESCRIPTION
The transifex command line tool we use to pull translations introduced a fix that broke the existing translation pulls.
So, in order to fix this, I've updated the` tx pull `command to use the `-t` flag along with the existing flags.

To get the more context on this, please have a look into this [issue](https://github.com/edx/edx-arch-experiments/issues/77)