### PR TITLE
style: change lambda variables for quality

### DIFF
--- a/designer/apps/branding/tests/utils.py
+++ b/designer/apps/branding/tests/utils.py
@@ -18,5 +18,5 @@ class BrandingFactory(factory.django.DjangoModelFactory):
         model = Branding
 
     organization_logo_image = factory.SubFactory(ImageFactory)
-    organization_logo_alt_text = factory.LazyAttribute(lambda l: fake.bs())
-    banner_border_color = factory.LazyAttribute(lambda l: fake.safe_hex_color())
+    organization_logo_alt_text = factory.LazyAttribute(lambda a: fake.bs())
+    banner_border_color = factory.LazyAttribute(lambda a: fake.safe_hex_color())

--- a/designer/apps/core/tests/utils.py
+++ b/designer/apps/core/tests/utils.py
@@ -72,7 +72,7 @@ class SiteFactory(factory.django.DjangoModelFactory):
         model = Site
 
     class Params:
-        company_name = factory.LazyAttribute(lambda l: fake.company())
+        company_name = factory.LazyAttribute(lambda a: fake.company())
 
     site_name = factory.LazyAttribute(lambda o: o.company_name)
     hostname = factory.LazyAttribute(
@@ -89,7 +89,7 @@ class ImageFactory(factory.django.DjangoModelFactory):
         model = Image
 
     class Params:
-        image_title = factory.LazyAttribute(lambda l: ' '.join(fake.words(nb=3)))
+        image_title = factory.LazyAttribute(lambda a: ' '.join(fake.words(nb=3)))
 
     title = factory.LazyAttribute(lambda o: o.image_title)
     file = factory.LazyAttribute(
@@ -106,7 +106,7 @@ class DocumentFactory(factory.django.DjangoModelFactory):
         model = Document
 
     class Params:
-        doc_title = factory.LazyAttribute(lambda l: ' '.join([word.capitalize() for word in fake.words(nb=3)]))
+        doc_title = factory.LazyAttribute(lambda a: ' '.join([word.capitalize() for word in fake.words(nb=3)]))
 
     title = factory.LazyAttribute(lambda o: o.doc_title)
     file = factory.LazyAttribute(

--- a/designer/apps/pages/tests/utils.py
+++ b/designer/apps/pages/tests/utils.py
@@ -44,11 +44,11 @@ class ExternalProgramWebsiteFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = ExternalProgramWebsite
 
-    display = factory.LazyAttribute(lambda l: fake.boolean())
-    header = factory.LazyAttribute(lambda l: ' '.join([word.capitalize() for word in fake.words(nb=3)]))
-    description = factory.LazyAttribute(lambda l: f'<ul>{[f"<li>{s}</li>" for s in fake.sentences(nb=4)]}</ul>')
-    link_display_text = factory.LazyAttribute(lambda l: fake.sentence())
-    link_url = factory.LazyAttribute(lambda l: fake.url())
+    display = factory.LazyAttribute(lambda a: fake.boolean())
+    header = factory.LazyAttribute(lambda a: ' '.join([word.capitalize() for word in fake.words(nb=3)]))
+    description = factory.LazyAttribute(lambda a: f'<ul>{[f"<li>{s}</li>" for s in fake.sentences(nb=4)]}</ul>')
+    link_display_text = factory.LazyAttribute(lambda a: fake.sentence())
+    link_url = factory.LazyAttribute(lambda a: fake.url())
     page = factory.LazyAttribute(lambda o: create_program_page(site=SiteFactory()))
 
 
@@ -99,10 +99,10 @@ class ProgramDocumentsFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = ProgramDocuments
 
-    display = factory.LazyAttribute(lambda l: fake.boolean())
-    header = factory.LazyAttribute(lambda l: ' '.join([word.capitalize() for word in fake.words(nb=3)]))
-    documents = factory.LazyAttribute(lambda l: _create_program_documents())
-    page = factory.LazyAttribute(lambda l: create_program_page(site=SiteFactory()))
+    display = factory.LazyAttribute(lambda a: fake.boolean())
+    header = factory.LazyAttribute(lambda a: ' '.join([word.capitalize() for word in fake.words(nb=3)]))
+    documents = factory.LazyAttribute(lambda a: _create_program_documents())
+    page = factory.LazyAttribute(lambda a: create_program_page(site=SiteFactory()))
 
 
 def create_program_page(


### PR DESCRIPTION
This [Python Requirements Update](https://github.com/edx/portal-designer/pull/206) is failing a quality check due to ambiguous variables. This PR updates the variables to fix the quality check:

The error: 
`E741 ambiguous variable name 'l'`

Here's [more info on the error](https://www.flake8rules.com/rules/E741.html#:~:text=Variables%20named%20I%20%2C%20O%20%2C%20and,variables%20to%20something%20more%20descriptive.).