### PR TITLE
chore: upgrade requirements

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -26,7 +26,7 @@ coreschema==0.0.4
     # via
     #   coreapi
     #   drf-yasg
-cryptography==40.0.1
+cryptography==40.0.2
     # via
     #   pyjwt
     #   social-auth-core
@@ -70,7 +70,7 @@ django-storages==1.13.2
     # via -r requirements/base.in
 django-taggit==2.1.0
     # via wagtail
-django-treebeard==4.6.1
+django-treebeard==4.7
     # via wagtail
 django-waffle==3.0.0
     # via
@@ -99,12 +99,12 @@ edx-auth-backends==4.1.0
     # via -r requirements/base.in
 edx-django-release-util==1.2.0
     # via -r requirements/base.in
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.7.0
     # via -r requirements/base.in
 edx-opaque-keys==2.3.0
     # via edx-drf-extensions
@@ -120,7 +120,7 @@ html5lib==1.1
     # via wagtail
 idna==3.4
     # via requests
-inflect==6.0.2
+inflect==6.0.4
     # via -r requirements/base.in
 inflection==0.5.1
     # via drf-yasg
@@ -132,7 +132,7 @@ l18n==2021.3
     # via wagtail
 markupsafe==2.1.2
     # via jinja2
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/base.in
 mysqlclient==2.1.1
     # via -r requirements/base.in
@@ -144,13 +144,13 @@ oauthlib==3.2.2
     #   social-auth-core
 openpyxl==3.1.2
     # via tablib
-packaging==23.0
+packaging==23.1
     # via drf-yasg
 pbr==5.11.1
     # via stevedore
 pillow==9.5.0
     # via wagtail
-psutil==5.9.4
+psutil==5.9.5
     # via edx-django-utils
 pycparser==2.21
     # via cffi
@@ -225,9 +225,9 @@ social-auth-core==4.4.1
     #   -r requirements/base.in
     #   edx-auth-backends
     #   social-auth-app-django
-soupsieve==2.4
+soupsieve==2.4.1
     # via beautifulsoup4
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via django
 stevedore==5.0.0
     # via
@@ -255,7 +255,7 @@ willow==1.4.1
     # via wagtail
 xlrd==2.0.1
     # via tablib
-xlsxwriter==3.0.9
+xlsxwriter==3.1.0
     # via wagtail
 xlwt==1.3.0
     # via tablib

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -12,15 +12,11 @@ asgiref==3.6.0
     # via
     #   -r requirements/quality.txt
     #   django
-astroid==2.15.2
+astroid==2.15.3
     # via
     #   -r requirements/quality.txt
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   pytest
 beautifulsoup4==4.9.3
     # via
     #   -r requirements/quality.txt
@@ -70,12 +66,11 @@ coreschema==0.0.4
     #   -r requirements/quality.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/quality.txt
-    #   codecov
     #   pytest-cov
-cryptography==40.0.1
+cryptography==40.0.2
     # via
     #   -r requirements/quality.txt
     #   pyjwt
@@ -145,7 +140,7 @@ django-taggit==2.1.0
     # via
     #   -r requirements/quality.txt
     #   wagtail
-django-treebeard==4.6.1
+django-treebeard==4.7
     # via
     #   -r requirements/quality.txt
     #   wagtail
@@ -180,12 +175,12 @@ edx-auth-backends==4.1.0
     # via -r requirements/quality.txt
 edx-django-release-util==1.2.0
     # via -r requirements/quality.txt
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/quality.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.7.0
     # via -r requirements/quality.txt
 edx-i18n-tools==0.9.2
     # via -r requirements/dev.in
@@ -209,11 +204,11 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/quality.txt
-faker==18.3.2
+faker==18.4.0
     # via
     #   -r requirements/quality.txt
     #   factory-boy
-filelock==3.10.7
+filelock==3.12.0
     # via
     #   -r requirements/quality.txt
     #   tox
@@ -230,7 +225,7 @@ idna==3.4
     # via
     #   -r requirements/quality.txt
     #   requests
-inflect==6.0.2
+inflect==6.0.4
     # via -r requirements/quality.txt
 inflection==0.5.1
     # via
@@ -270,7 +265,7 @@ mccabe==0.7.0
     # via
     #   -r requirements/quality.txt
     #   pylint
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/quality.txt
 mysqlclient==2.1.1
     # via -r requirements/quality.txt
@@ -287,7 +282,7 @@ openpyxl==3.1.2
     # via
     #   -r requirements/quality.txt
     #   tablib
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/pip-tools.txt
     #   -r requirements/quality.txt
@@ -305,7 +300,7 @@ pillow==9.5.0
     # via
     #   -r requirements/quality.txt
     #   wagtail
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.txt
 platformdirs==3.2.0
     # via
@@ -320,7 +315,7 @@ pluggy==1.0.0
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
@@ -344,7 +339,7 @@ pydantic==1.10.7
     #   inflect
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
-pygments==2.14.0
+pygments==2.15.1
     # via diff-cover
 pyjwkest==1.4.2
     # via
@@ -390,7 +385,7 @@ pyproject-hooks==1.0.0
     # via
     #   -r requirements/pip-tools.txt
     #   build
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements/quality.txt
     #   pytest-cov
@@ -429,7 +424,6 @@ pyyaml==6.0
 requests==2.28.2
     # via
     #   -r requirements/quality.txt
-    #   codecov
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -484,11 +478,11 @@ social-auth-core==4.4.1
     #   -r requirements/quality.txt
     #   edx-auth-backends
     #   social-auth-app-django
-soupsieve==2.4
+soupsieve==2.4.1
     # via
     #   -r requirements/quality.txt
     #   beautifulsoup4
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/quality.txt
     #   django
@@ -544,7 +538,7 @@ urllib3==1.26.15
     # via
     #   -r requirements/quality.txt
     #   requests
-virtualenv==20.21.0
+virtualenv==20.22.0
     # via
     #   -r requirements/quality.txt
     #   tox
@@ -572,7 +566,7 @@ xlrd==2.0.1
     # via
     #   -r requirements/quality.txt
     #   tablib
-xlsxwriter==3.0.9
+xlsxwriter==3.1.0
     # via
     #   -r requirements/quality.txt
     #   wagtail

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -14,15 +14,11 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.2
+astroid==2.15.3
     # via
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 babel==2.12.1
     # via sphinx
 beautifulsoup4==4.9.3
@@ -68,12 +64,11 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
-    #   codecov
     #   pytest-cov
-cryptography==40.0.1
+cryptography==40.0.2
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -135,7 +130,7 @@ django-taggit==2.1.0
     # via
     #   -r requirements/test.txt
     #   wagtail
-django-treebeard==4.6.1
+django-treebeard==4.7
     # via
     #   -r requirements/test.txt
     #   wagtail
@@ -178,12 +173,12 @@ edx-auth-backends==4.1.0
     # via -r requirements/test.txt
 edx-django-release-util==1.2.0
     # via -r requirements/test.txt
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.7.0
     # via -r requirements/test.txt
 edx-lint==5.3.4
     # via -r requirements/test.txt
@@ -205,11 +200,11 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.3.2
+faker==18.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.10.7
+filelock==3.12.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -228,9 +223,9 @@ idna==3.4
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.1.0
+importlib-metadata==6.5.0
     # via sphinx
-inflect==6.0.2
+inflect==6.0.4
     # via -r requirements/test.txt
 inflection==0.5.1
     # via
@@ -270,7 +265,7 @@ mccabe==0.7.0
     # via
     #   -r requirements/test.txt
     #   pylint
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/test.txt
 mysqlclient==2.1.1
     # via -r requirements/test.txt
@@ -287,7 +282,7 @@ openpyxl==3.1.2
     # via
     #   -r requirements/test.txt
     #   tablib
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   drf-yasg
@@ -312,7 +307,7 @@ pluggy==1.0.0
     #   -r requirements/test.txt
     #   pytest
     #   tox
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -332,7 +327,7 @@ pydantic==1.10.7
     # via
     #   -r requirements/test.txt
     #   inflect
-pygments==2.14.0
+pygments==2.15.1
     # via
     #   doc8
     #   readme-renderer
@@ -377,7 +372,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -402,7 +397,6 @@ python3-openid==3.2.0
 pytz==2023.3
     # via
     #   -r requirements/test.txt
-    #   babel
     #   django
     #   django-modelcluster
     #   djangorestframework
@@ -418,7 +412,6 @@ readme-renderer==37.3
 requests==2.28.2
     # via
     #   -r requirements/test.txt
-    #   codecov
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -476,7 +469,7 @@ social-auth-core==4.4.1
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
-soupsieve==2.4
+soupsieve==2.4.1
     # via
     #   -r requirements/test.txt
     #   beautifulsoup4
@@ -496,7 +489,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/test.txt
     #   django
@@ -548,7 +541,7 @@ urllib3==1.26.15
     # via
     #   -r requirements/test.txt
     #   requests
-virtualenv==20.21.0
+virtualenv==20.22.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -571,7 +564,7 @@ xlrd==2.0.1
     # via
     #   -r requirements/test.txt
     #   tablib
-xlsxwriter==3.0.9
+xlsxwriter==3.1.0
     # via
     #   -r requirements/test.txt
     #   wagtail

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -8,9 +8,9 @@ build==0.10.0
     # via pip-tools
 click==8.1.3
     # via pip-tools
-packaging==23.0
+packaging==23.1
     # via build
-pip-tools==6.12.3
+pip-tools==6.13.0
     # via -r requirements/pip-tools.in
 pyproject-hooks==1.0.0
     # via build

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,7 @@ wheel==0.40.0
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==23.0.1
+pip==23.1
     # via -r requirements/pip.in
-setuptools==67.6.1
+setuptools==67.7.0
     # via -r requirements/pip.in

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -16,9 +16,9 @@ beautifulsoup4==4.9.3
     # via
     #   -r requirements/base.txt
     #   wagtail
-boto3==1.26.104
+boto3==1.26.116
     # via -r requirements/production.in
-botocore==1.29.104
+botocore==1.29.116
     # via
     #   boto3
     #   s3transfer
@@ -48,7 +48,7 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-cryptography==40.0.1
+cryptography==40.0.2
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -100,7 +100,7 @@ django-taggit==2.1.0
     # via
     #   -r requirements/base.txt
     #   wagtail
-django-treebeard==4.6.1
+django-treebeard==4.7
     # via
     #   -r requirements/base.txt
     #   wagtail
@@ -135,12 +135,12 @@ edx-auth-backends==4.1.0
     # via -r requirements/base.txt
 edx-django-release-util==1.2.0
     # via -r requirements/base.txt
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.7.0
     # via -r requirements/base.txt
 edx-opaque-keys==2.3.0
     # via
@@ -170,7 +170,7 @@ idna==3.4
     # via
     #   -r requirements/base.txt
     #   requests
-inflect==6.0.2
+inflect==6.0.4
     # via -r requirements/base.txt
 inflection==0.5.1
     # via
@@ -196,7 +196,7 @@ markupsafe==2.1.2
     # via
     #   -r requirements/base.txt
     #   jinja2
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/base.txt
 mysqlclient==2.1.1
     # via -r requirements/base.txt
@@ -213,7 +213,7 @@ openpyxl==3.1.2
     # via
     #   -r requirements/base.txt
     #   tablib
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -225,7 +225,7 @@ pillow==9.5.0
     # via
     #   -r requirements/base.txt
     #   wagtail
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -338,11 +338,11 @@ social-auth-core==4.4.1
     #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-app-django
-soupsieve==2.4
+soupsieve==2.4.1
     # via
     #   -r requirements/base.txt
     #   beautifulsoup4
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/base.txt
     #   django
@@ -387,7 +387,7 @@ xlrd==2.0.1
     # via
     #   -r requirements/base.txt
     #   tablib
-xlsxwriter==3.0.9
+xlsxwriter==3.1.0
     # via
     #   -r requirements/base.txt
     #   wagtail

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -12,15 +12,11 @@ asgiref==3.6.0
     # via
     #   -r requirements/test.txt
     #   django
-astroid==2.15.2
+astroid==2.15.3
     # via
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via
-    #   -r requirements/test.txt
-    #   pytest
 beautifulsoup4==4.9.3
     # via
     #   -r requirements/test.txt
@@ -62,12 +58,11 @@ coreschema==0.0.4
     #   -r requirements/test.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.txt
-    #   codecov
     #   pytest-cov
-cryptography==40.0.1
+cryptography==40.0.2
     # via
     #   -r requirements/test.txt
     #   pyjwt
@@ -129,7 +124,7 @@ django-taggit==2.1.0
     # via
     #   -r requirements/test.txt
     #   wagtail
-django-treebeard==4.6.1
+django-treebeard==4.7
     # via
     #   -r requirements/test.txt
     #   wagtail
@@ -164,12 +159,12 @@ edx-auth-backends==4.1.0
     # via -r requirements/test.txt
 edx-django-release-util==1.2.0
     # via -r requirements/test.txt
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.7.0
     # via -r requirements/test.txt
 edx-lint==5.3.4
     # via
@@ -191,11 +186,11 @@ exceptiongroup==1.1.1
     #   pytest
 factory-boy==3.2.1
     # via -r requirements/test.txt
-faker==18.3.2
+faker==18.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.10.7
+filelock==3.12.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -212,7 +207,7 @@ idna==3.4
     # via
     #   -r requirements/test.txt
     #   requests
-inflect==6.0.2
+inflect==6.0.4
     # via -r requirements/test.txt
 inflection==0.5.1
     # via
@@ -252,7 +247,7 @@ mccabe==0.7.0
     # via
     #   -r requirements/test.txt
     #   pylint
-mock==5.0.1
+mock==5.0.2
     # via -r requirements/test.txt
 mysqlclient==2.1.1
     # via -r requirements/test.txt
@@ -269,7 +264,7 @@ openpyxl==3.1.2
     # via
     #   -r requirements/test.txt
     #   tablib
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/test.txt
     #   drf-yasg
@@ -293,7 +288,7 @@ pluggy==1.0.0
     #   -r requirements/test.txt
     #   pytest
     #   tox
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -357,7 +352,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -395,7 +390,6 @@ pyyaml==6.0
 requests==2.28.2
     # via
     #   -r requirements/test.txt
-    #   codecov
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -448,11 +442,11 @@ social-auth-core==4.4.1
     #   -r requirements/test.txt
     #   edx-auth-backends
     #   social-auth-app-django
-soupsieve==2.4
+soupsieve==2.4.1
     # via
     #   -r requirements/test.txt
     #   beautifulsoup4
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/test.txt
     #   django
@@ -502,7 +496,7 @@ urllib3==1.26.15
     # via
     #   -r requirements/test.txt
     #   requests
-virtualenv==20.21.0
+virtualenv==20.22.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -524,7 +518,7 @@ xlrd==2.0.1
     # via
     #   -r requirements/test.txt
     #   tablib
-xlsxwriter==3.0.9
+xlsxwriter==3.1.0
     # via
     #   -r requirements/test.txt
     #   wagtail

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,12 +12,10 @@ asgiref==3.6.0
     # via
     #   -r requirements/base.txt
     #   django
-astroid==2.15.2
+astroid==2.15.3
     # via
     #   pylint
     #   pylint-celery
-attrs==22.2.0
-    # via pytest
 beautifulsoup4==4.9.3
     # via
     #   -r requirements/base.txt
@@ -57,12 +55,11 @@ coreschema==0.0.4
     #   -r requirements/base.txt
     #   coreapi
     #   drf-yasg
-coverage[toml]==7.2.2
+coverage[toml]==7.2.3
     # via
     #   -r requirements/test.in
-    #   codecov
     #   pytest-cov
-cryptography==40.0.1
+cryptography==40.0.2
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -121,7 +118,7 @@ django-taggit==2.1.0
     # via
     #   -r requirements/base.txt
     #   wagtail
-django-treebeard==4.6.1
+django-treebeard==4.7
     # via
     #   -r requirements/base.txt
     #   wagtail
@@ -156,12 +153,12 @@ edx-auth-backends==4.1.0
     # via -r requirements/base.txt
 edx-django-release-util==1.2.0
     # via -r requirements/base.txt
-edx-django-utils==5.3.0
+edx-django-utils==5.4.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==8.4.1
+edx-drf-extensions==8.7.0
     # via -r requirements/base.txt
 edx-lint==5.3.4
     # via -r requirements/test.in
@@ -181,11 +178,11 @@ exceptiongroup==1.1.1
     # via pytest
 factory-boy==3.2.1
     # via -r requirements/test.in
-faker==18.3.2
+faker==18.4.0
     # via
     #   -r requirements/test.in
     #   factory-boy
-filelock==3.10.7
+filelock==3.12.0
     # via
     #   tox
     #   virtualenv
@@ -201,7 +198,7 @@ idna==3.4
     # via
     #   -r requirements/base.txt
     #   requests
-inflect==6.0.2
+inflect==6.0.4
     # via -r requirements/base.txt
 inflection==0.5.1
     # via
@@ -232,7 +229,7 @@ markupsafe==2.1.2
     #   jinja2
 mccabe==0.7.0
     # via pylint
-mock==5.0.1
+mock==5.0.2
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
@@ -251,7 +248,7 @@ openpyxl==3.1.2
     # via
     #   -r requirements/base.txt
     #   tablib
-packaging==23.0
+packaging==23.1
     # via
     #   -r requirements/base.txt
     #   drf-yasg
@@ -273,7 +270,7 @@ pluggy==1.0.0
     # via
     #   pytest
     #   tox
-psutil==5.9.4
+psutil==5.9.5
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -325,7 +322,7 @@ pynacl==1.5.0
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pytest==7.2.2
+pytest==7.3.1
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -361,7 +358,6 @@ pyyaml==6.0
 requests==2.28.2
     # via
     #   -r requirements/base.txt
-    #   codecov
     #   coreapi
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -412,11 +408,11 @@ social-auth-core==4.4.1
     #   -r requirements/base.txt
     #   edx-auth-backends
     #   social-auth-app-django
-soupsieve==2.4
+soupsieve==2.4.1
     # via
     #   -r requirements/base.txt
     #   beautifulsoup4
-sqlparse==0.4.3
+sqlparse==0.4.4
     # via
     #   -r requirements/base.txt
     #   django
@@ -463,7 +459,7 @@ urllib3==1.26.15
     # via
     #   -r requirements/base.txt
     #   requests
-virtualenv==20.21.0
+virtualenv==20.22.0
     # via tox
 wagtail==2.16.3
     # via
@@ -483,7 +479,7 @@ xlrd==2.0.1
     # via
     #   -r requirements/base.txt
     #   tablib
-xlsxwriter==3.0.9
+xlsxwriter==3.1.0
     # via
     #   -r requirements/base.txt
     #   wagtail


### PR DESCRIPTION
The Python requirements action was failing due to an older version of pip-tools. I manually updated the version of that package, installed it, and then was able to run `make upgrade` successfully.