### PR TITLE
fix: install pkg-config dependency for mysqlclient>=2.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 FROM ubuntu:focal as app
 MAINTAINER sre@edx.org
 
+# Packages installed:
+
+# pkg-config; mysqlclient>=2.2.0 requires pkg-config (https://github.com/PyMySQL/mysqlclient/issues/620)
+
 RUN apt-get update && apt-get -qy install --no-install-recommends \
  language-pack-en \
  locales \
  python3.8 \
  python3-pip \
  libmysqlclient-dev \
+ pkg-config \
  libssl-dev \
  python3-dev \
  gcc \


### PR DESCRIPTION
Repositiories that depend on mysqlclient>=2.2.0 will need to install the package pkg-config in their Dockerfile: PyMySQL/mysqlclient#620. This commit installs the pkg-config package in the Dockerfile.

If this is missing, then pip install of mysqlclient fails with an error that includes the following:

Exception: Can not find valid pkg-config name.
Specify MYSQLCLIENT_CFLAGS and MYSQLCLIENT_LDFLAGS env vars manually

See https://github.com/edx/edx-arch-experiments/issues/349.