### PR TITLE
[Django 4.2]: Fix: Add support for Django 4.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8"]
-        toxenv: [django32, quality, pii_check, check_keywords]
+        toxenv: [django32, django42, quality, pii_check, check_keywords]
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
@@ -29,5 +29,5 @@ jobs:
         TOXENV: ${{ matrix.toxenv }}
       run: tox
     - name: Codecov
-      if: matrix.python-version == '3.8' && matrix.toxenv == 'django32'
+      if: matrix.python-version == '3.8' && matrix.toxenv == 'django42'
       uses: codecov/codecov-action@v2

--- a/designer/apps/api/urls.py
+++ b/designer/apps/api/urls.py
@@ -4,10 +4,11 @@ Root API URLs.
 All API URLs should be versioned, so urlpatterns should only
 contain namespaces for the active versions of the API.
 """
-from django.urls import re_path, include
+from django.urls import include, path
+
 
 app_name = 'api'
 
 urlpatterns = [
-    re_path(r'^v1/', include(('designer.apps.api.v1.urls', 'v1'))),
+    path('v1/', include(('designer.apps.api.v1.urls', 'v1'))),
 ]

--- a/designer/apps/core/__init__.py
+++ b/designer/apps/core/__init__.py
@@ -1,3 +1,1 @@
 """ Core app for designer """
-
-default_app_config = 'designer.apps.core.apps.CoreConfig'

--- a/designer/apps/core/admin.py
+++ b/designer/apps/core/admin.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 from designer.apps.core.models import User
 
 
+@admin.register(User)
 class CustomUserAdmin(UserAdmin):
     """ Admin configuration for the custom User model. """
     list_display = ('username', 'email', 'full_name', 'first_name', 'last_name', 'is_staff')
@@ -17,6 +18,3 @@ class CustomUserAdmin(UserAdmin):
                                        'groups', 'user_permissions')}),
         (_('Important dates'), {'fields': ('last_login', 'date_joined')}),
     )
-
-
-admin.site.register(User, CustomUserAdmin)

--- a/designer/urls.py
+++ b/designer/urls.py
@@ -17,7 +17,7 @@ import os
 
 from auth_backends.urls import oauth2_urlpatterns
 from django.conf import settings
-from django.urls import re_path, include
+from django.urls import include, path
 from django.conf.urls.static import static
 from django.contrib import admin
 from django.views.generic import RedirectView
@@ -42,21 +42,21 @@ schema_view = get_schema_view(
 )
 
 urlpatterns = oauth2_urlpatterns + [
-    re_path(r'^api/', include('designer.apps.api.urls')),
-    re_path(r'^api-docs/$', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
+    path('api/', include('designer.apps.api.urls')),
+    path('api-docs/', schema_view.with_ui('swagger', cache_timeout=0), name='schema-swagger-ui'),
     # Use the same auth views for all logins, including those originating from the browseable API.
-    re_path(r'^api-auth/', include(oauth2_urlpatterns)),
-    re_path(r'^auto_auth/$', core_views.AutoAuth.as_view(), name='auto_auth'),
-    re_path(r'^health/$', core_views.health, name='health'),
-    re_path(r'^documents/', include(wagtaildocs_urls)),
-    re_path(r'^pages/', include(wagtail_urls)),
-    re_path(r'^cms/login/$', core_views.wagtail_admin_access_check),
-    re_path(r'^cms/logout/$', RedirectView.as_view(url='/logout/')),
-    re_path(r'^cms/sites/new/$', SiteCreationView.as_view(), name='create-new-site'),
-    re_path(r'^cms/', include(wagtailadmin_urls)),
-    re_path(r'^$', RedirectView.as_view(url='/cms/'))
+    path('api-auth/', include(oauth2_urlpatterns)),
+    path('auto_auth/', core_views.AutoAuth.as_view(), name='auto_auth'),
+    path('health/', core_views.health, name='health'),
+    path('documents/', include(wagtaildocs_urls)),
+    path('pages/', include(wagtail_urls)),
+    path('cms/login/', core_views.wagtail_admin_access_check),
+    path('cms/logout/', RedirectView.as_view(url='/logout/')),
+    path('cms/sites/new/', SiteCreationView.as_view(), name='create-new-site'),
+    path('cms/', include(wagtailadmin_urls)),
+    path('', RedirectView.as_view(url='/cms/'))
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if settings.DEBUG and os.environ.get('ENABLE_DJANGO_TOOLBAR', False):  # pragma: no cover
     import debug_toolbar
-    urlpatterns.append(re_path(r'^__debug__/', include(debug_toolbar.urls)))
+    urlpatterns.append(path('__debug__/', include(debug_toolbar.urls)))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38-django32
+envlist = py38-django{32,42}
 skipsdist = true
 
 [pytest]
@@ -9,6 +9,7 @@ testpaths = designer/apps
 [testenv]
 deps =
     django32: -r requirements/django.txt
+    django42: Django>=4.2,<5.0
     -r {toxinidir}/requirements/test.txt
 commands =
     {posargs:python -Wd -m pytest}


### PR DESCRIPTION
Adding django42 support only.
- codemod used
   - [modernize_tox_django42](https://github.com/openedx/repo-tools/blob/master/edx_repo_tools/codemods/django42/tox_moderniser_django42.py)
   - [modernize_github_actions_django42](https://github.com/openedx/repo-tools/blob/master/edx_repo_tools/codemods/django42/github_actions_modernizer_django42.py)
   - [remove_providing_args](https://github.com/openedx/repo-tools/blob/master/edx_repo_tools/codemods/django42/remove_providing_args_arg.py)
   - [django-upgrade](https://github.com/adamchainz/django-upgrade)
  
- Resolves https://github.com/edx/portal-designer/issues/251