### PR TITLE
build: add pymemcache dependency

### DIFF
--- a/requirements/production.in
+++ b/requirements/production.in
@@ -7,3 +7,4 @@ gunicorn
 #mysqlclient
 PyYAML
 python-memcached
+pymemcache

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -234,6 +234,8 @@ pyjwt[crypto]==2.8.0
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   social-auth-core
+pymemcache==4.0.0
+    # via -r requirements/production.in
 pymongo==3.13.0
     # via
     #   -r requirements/base.txt


### PR DESCRIPTION
## Description
- Under the issue https://github.com/edx/portal-designer/issues/253, adding the `pymemcache` dependency in requirements to prepare for cache backend migration. 