### PR TITLE
build: migrate devstack cache backend

### DIFF
--- a/designer/settings/devstack.py
+++ b/designer/settings/devstack.py
@@ -31,8 +31,9 @@ JWT_AUTH['JWT_ISSUERS'].append({
 
 # CACHES = {
 #     'default': {
-#         'BACKEND': 'django.core.cache.backends.memcached.MemcachedCache',
+#         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
 #         'LOCATION': os.environ.get('CACHE_LOCATION', 'memcached:11211'),
+#         'OPTIONS': {"no_delay": True, "ignore_exec": True, "use_pooling": True},
 #     }
 # }
 


### PR DESCRIPTION
## Description
- Under the issue https://github.com/edx/portal-designer/issues/253, migrating the devstack cache backend from `MemcachedCache` to `PyMemcacheCache`. 
- devstack cache is not being used right now, but still updating the configuration to keep the standard same with all the other IDAs.