### PR TITLE
fix: fix the cache backend options parameter

### DIFF
--- a/designer/settings/devstack.py
+++ b/designer/settings/devstack.py
@@ -33,7 +33,7 @@ JWT_AUTH['JWT_ISSUERS'].append({
 #     'default': {
 #         'BACKEND': 'django.core.cache.backends.memcached.PyMemcacheCache',
 #         'LOCATION': os.environ.get('CACHE_LOCATION', 'memcached:11211'),
-#         'OPTIONS': {"no_delay": True, "ignore_exec": True, "use_pooling": True},
+#         'OPTIONS': {"no_delay": True, "ignore_exc": True, "use_pooling": True},
 #     }
 # }
 


### PR DESCRIPTION
## Description
- The parameter needs to be `ignore_exc` instead of `ignore_exec` for cache backend options.