### PR TITLE
fix: remove JWT_AUTH_REFRESH_COOKIE

### DIFF
--- a/designer/settings/base.py
+++ b/designer/settings/base.py
@@ -224,7 +224,6 @@ JWT_AUTH = {
     'JWT_PUBLIC_SIGNING_JWK_SET': None,
     'JWT_AUTH_COOKIE_HEADER_PAYLOAD': 'edx-jwt-cookie-header-payload',
     'JWT_AUTH_COOKIE_SIGNATURE': 'edx-jwt-cookie-signature',
-    'JWT_AUTH_REFRESH_COOKIE': 'edx-jwt-refresh-cookie',
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
 }
 


### PR DESCRIPTION
Remove unused JWT_AUTH_REFRESH_COOKIE setting. This setting was never actually used, so there is no timing issues.

See DEPR for details:
https://github.com/openedx/public-engineering/issues/190