### PR TITLE
feat: remove piptools from dev deps

### DIFF
--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -2,7 +2,6 @@
 
 -c constraints.txt
 
--r pip-tools.txt          # pip-tools and its dependencies, for managing requirements files
 -r quality.txt            # Core and quality check dependencies
 
 diff-cover                # Changeset diff test coverage


### PR DESCRIPTION
pip tools and [this constraint](https://github.com/openedx/edx-lint/pull/406) will conflict. Normally not an issue since the constraint doesn't apply to pip-tools.in but because we have dev depend on pip-tools in this repo the dev requirements are unable to compile (https://github.com/edx/portal-designer/actions/runs/8394856396/job/22992880471)

We should be able to run the requirements job again once this is merged