### PR TITLE
Revert Python requirements upgrades.

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -4,6 +4,8 @@
 #
 #    make upgrade
 #
+annotated-types==0.6.0
+    # via pydantic
 anyascii==0.3.2
     # via wagtail
 asgiref==3.8.1
@@ -16,9 +18,9 @@ backports-zoneinfo==0.2.1
     #   djangorestframework
 beautifulsoup4==4.12.3
     # via wagtail
-boto3==1.34.75
+boto3==1.34.70
     # via -r requirements/base.in
-botocore==1.34.75
+botocore==1.34.70
     # via
     #   boto3
     #   s3transfer
@@ -108,16 +110,16 @@ drf-yasg==1.21.7
     #   edx-api-doc-tools
 edx-api-doc-tools==1.7.0
     # via -r requirements/base.in
-edx-auth-backends==4.3.0
+edx-auth-backends==4.2.0
     # via -r requirements/base.in
-edx-django-release-util==1.4.0
+edx-django-release-util==1.3.0
     # via -r requirements/base.in
-edx-django-utils==5.12.0
+edx-django-utils==5.11.0
     # via
     #   -r requirements/base.in
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==10.3.0
+edx-drf-extensions==10.2.0
     # via -r requirements/base.in
 edx-opaque-keys==2.5.1
     # via edx-drf-extensions
@@ -133,11 +135,7 @@ html5lib==1.1
     # via wagtail
 idna==3.6
     # via requests
-importlib-metadata==6.11.0
-    # via
-    #   -c requirements/common_constraints.txt
-    #   typeguard
-inflect==7.2.0
+inflect==7.0.0
     # via -r requirements/base.in
 inflection==0.5.1
     # via drf-yasg
@@ -151,11 +149,9 @@ laces==0.1.1
     # via wagtail
 mock==5.1.0
     # via -r requirements/base.in
-more-itertools==10.2.0
-    # via inflect
 mysqlclient==2.2.4
     # via -r requirements/base.in
-newrelic==9.8.0
+newrelic==9.7.1
     # via edx-django-utils
 oauthlib==3.2.2
     # via
@@ -167,16 +163,20 @@ packaging==24.0
     # via drf-yasg
 pbr==6.0.0
     # via stevedore
-pillow==10.3.0
+pillow==10.2.0
     # via
     #   pillow-heif
     #   wagtail
-pillow-heif==0.16.0
+pillow-heif==0.15.0
     # via willow
 psutil==5.9.8
     # via edx-django-utils
-pycparser==2.22
+pycparser==2.21
     # via cffi
+pydantic==2.6.4
+    # via inflect
+pydantic-core==2.16.3
+    # via pydantic
 pyjwt[crypto]==2.8.0
     # via
     #   drf-jwt
@@ -246,14 +246,14 @@ stevedore==5.2.0
     #   edx-opaque-keys
 telepath==0.3.1
     # via wagtail
-typeguard==4.2.1
-    # via inflect
 typing-extensions==4.10.0
     # via
+    #   annotated-types
     #   asgiref
     #   edx-opaque-keys
     #   inflect
-    #   typeguard
+    #   pydantic
+    #   pydantic-core
 uritemplate==4.1.1
     # via drf-yasg
 urllib3==1.26.18
@@ -269,6 +269,4 @@ willow[heif]==1.8.0
     #   wagtail
     #   willow
 zipp==3.18.1
-    # via
-    #   -r requirements/base.in
-    #   importlib-metadata
+    # via -r requirements/base.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,9 +16,9 @@ backports-zoneinfo==0.2.1
     #   djangorestframework
 beautifulsoup4==4.12.3
     # via wagtail
-boto3==1.34.80
+boto3==1.34.75
     # via -r requirements/base.in
-botocore==1.34.80
+botocore==1.34.75
     # via
     #   boto3
     #   s3transfer
@@ -106,7 +106,7 @@ drf-yasg==1.21.7
     # via
     #   -r requirements/base.in
     #   edx-api-doc-tools
-edx-api-doc-tools==1.8.0
+edx-api-doc-tools==1.7.0
     # via -r requirements/base.in
 edx-auth-backends==4.3.0
     # via -r requirements/base.in
@@ -248,7 +248,7 @@ telepath==0.3.1
     # via wagtail
 typeguard==4.2.1
     # via inflect
-typing-extensions==4.11.0
+typing-extensions==4.10.0
     # via
     #   asgiref
     #   edx-opaque-keys
@@ -260,7 +260,7 @@ urllib3==1.26.18
     # via
     #   botocore
     #   requests
-wagtail==6.0.2
+wagtail==6.0.1
     # via -r requirements/base.in
 webencodings==0.5.1
     # via html5lib

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -27,9 +27,9 @@ beautifulsoup4==4.12.3
     # via
     #   -r requirements/quality.txt
     #   wagtail
-boto3==1.34.80
+boto3==1.34.75
     # via -r requirements/quality.txt
-botocore==1.34.80
+botocore==1.34.75
     # via
     #   -r requirements/quality.txt
     #   boto3
@@ -67,7 +67,7 @@ click-log==0.4.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
-code-annotations==1.8.0
+code-annotations==1.7.0
     # via
     #   -r requirements/quality.txt
     #   edx-lint
@@ -187,7 +187,7 @@ drf-yasg==1.21.7
     # via
     #   -r requirements/quality.txt
     #   edx-api-doc-tools
-edx-api-doc-tools==1.8.0
+edx-api-doc-tools==1.7.0
     # via -r requirements/quality.txt
 edx-auth-backends==4.3.0
     # via -r requirements/quality.txt
@@ -222,7 +222,7 @@ exceptiongroup==1.2.0
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/quality.txt
-faker==24.7.1
+faker==24.4.0
     # via
     #   -r requirements/quality.txt
     #   factory-boy
@@ -280,7 +280,7 @@ laces==0.1.1
     # via
     #   -r requirements/quality.txt
     #   wagtail
-lxml==5.2.1
+lxml==5.2.0
     # via edx-i18n-tools
 markupsafe==2.1.5
     # via
@@ -318,7 +318,7 @@ packaging==24.0
     #   pyproject-api
     #   pytest
     #   tox
-path==16.14.0
+path==16.10.0
     # via edx-i18n-tools
 pbr==6.0.0
     # via
@@ -524,7 +524,7 @@ typeguard==4.2.1
     # via
     #   -r requirements/quality.txt
     #   inflect
-typing-extensions==4.11.0
+typing-extensions==4.10.0
     # via
     #   -r requirements/quality.txt
     #   asgiref
@@ -547,7 +547,7 @@ virtualenv==20.25.1
     # via
     #   -r requirements/quality.txt
     #   tox
-wagtail==6.0.2
+wagtail==6.0.1
     # via -r requirements/quality.txt
 webencodings==0.5.1
     # via

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+annotated-types==0.6.0
+    # via
+    #   -r requirements/quality.txt
+    #   pydantic
 anyascii==0.3.2
     # via
     #   -r requirements/quality.txt
@@ -27,9 +31,9 @@ beautifulsoup4==4.12.3
     # via
     #   -r requirements/quality.txt
     #   wagtail
-boto3==1.34.75
+boto3==1.34.70
     # via -r requirements/quality.txt
-botocore==1.34.75
+botocore==1.34.70
     # via
     #   -r requirements/quality.txt
     #   boto3
@@ -189,16 +193,16 @@ drf-yasg==1.21.7
     #   edx-api-doc-tools
 edx-api-doc-tools==1.7.0
     # via -r requirements/quality.txt
-edx-auth-backends==4.3.0
+edx-auth-backends==4.2.0
     # via -r requirements/quality.txt
-edx-django-release-util==1.4.0
+edx-django-release-util==1.3.0
     # via -r requirements/quality.txt
-edx-django-utils==5.12.0
+edx-django-utils==5.11.0
     # via
     #   -r requirements/quality.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==10.3.0
+edx-drf-extensions==10.2.0
     # via -r requirements/quality.txt
 edx-i18n-tools==1.3.0
     # via -r requirements/dev.in
@@ -243,12 +247,7 @@ idna==3.6
     # via
     #   -r requirements/quality.txt
     #   requests
-importlib-metadata==6.11.0
-    # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/quality.txt
-    #   typeguard
-inflect==7.2.0
+inflect==7.0.0
     # via -r requirements/quality.txt
 inflection==0.5.1
     # via
@@ -280,7 +279,7 @@ laces==0.1.1
     # via
     #   -r requirements/quality.txt
     #   wagtail
-lxml==5.2.0
+lxml==5.1.0
     # via edx-i18n-tools
 markupsafe==2.1.5
     # via
@@ -292,13 +291,9 @@ mccabe==0.7.0
     #   pylint
 mock==5.1.0
     # via -r requirements/quality.txt
-more-itertools==10.2.0
-    # via
-    #   -r requirements/quality.txt
-    #   inflect
 mysqlclient==2.2.4
     # via -r requirements/quality.txt
-newrelic==9.8.0
+newrelic==9.7.1
     # via
     #   -r requirements/quality.txt
     #   edx-django-utils
@@ -324,12 +319,12 @@ pbr==6.0.0
     # via
     #   -r requirements/quality.txt
     #   stevedore
-pillow==10.3.0
+pillow==10.2.0
     # via
     #   -r requirements/quality.txt
     #   pillow-heif
     #   wagtail
-pillow-heif==0.16.0
+pillow-heif==0.15.0
     # via
     #   -r requirements/quality.txt
     #   willow
@@ -353,10 +348,18 @@ psutil==5.9.8
     #   edx-django-utils
 pycodestyle==2.11.1
     # via -r requirements/quality.txt
-pycparser==2.22
+pycparser==2.21
     # via
     #   -r requirements/quality.txt
     #   cffi
+pydantic==2.6.4
+    # via
+    #   -r requirements/quality.txt
+    #   inflect
+pydantic-core==2.16.3
+    # via
+    #   -r requirements/quality.txt
+    #   pydantic
 pydocstyle==6.3.0
     # via -r requirements/quality.txt
 pygments==2.17.2
@@ -520,20 +523,18 @@ tomlkit==0.12.4
     #   pylint
 tox==4.14.2
     # via -r requirements/quality.txt
-typeguard==4.2.1
-    # via
-    #   -r requirements/quality.txt
-    #   inflect
 typing-extensions==4.10.0
     # via
     #   -r requirements/quality.txt
+    #   annotated-types
     #   asgiref
     #   astroid
     #   edx-opaque-keys
     #   faker
     #   inflect
+    #   pydantic
+    #   pydantic-core
     #   pylint
-    #   typeguard
 uritemplate==4.1.1
     # via
     #   -r requirements/quality.txt
@@ -558,6 +559,4 @@ willow[heif]==1.8.0
     #   -r requirements/quality.txt
     #   wagtail
 zipp==3.18.1
-    # via
-    #   -r requirements/quality.txt
-    #   importlib-metadata
+    # via -r requirements/quality.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,6 +6,10 @@
 #
 alabaster==0.7.13
     # via sphinx
+annotated-types==0.6.0
+    # via
+    #   -r requirements/test.txt
+    #   pydantic
 anyascii==0.3.2
     # via
     #   -r requirements/test.txt
@@ -31,9 +35,9 @@ beautifulsoup4==4.12.3
     # via
     #   -r requirements/test.txt
     #   wagtail
-boto3==1.34.75
+boto3==1.34.70
     # via -r requirements/test.txt
-botocore==1.34.75
+botocore==1.34.70
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -192,16 +196,16 @@ drf-yasg==1.21.7
     #   edx-api-doc-tools
 edx-api-doc-tools==1.7.0
     # via -r requirements/test.txt
-edx-auth-backends==4.3.0
+edx-auth-backends==4.2.0
     # via -r requirements/test.txt
-edx-django-release-util==1.4.0
+edx-django-release-util==1.3.0
     # via -r requirements/test.txt
-edx-django-utils==5.12.0
+edx-django-utils==5.11.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==10.3.0
+edx-drf-extensions==10.2.0
     # via -r requirements/test.txt
 edx-lint==5.3.6
     # via -r requirements/test.txt
@@ -246,12 +250,9 @@ idna==3.6
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==6.11.0
-    # via
-    #   -r requirements/test.txt
-    #   sphinx
-    #   typeguard
-inflect==7.2.0
+importlib-metadata==7.1.0
+    # via sphinx
+inflect==7.0.0
     # via -r requirements/test.txt
 inflection==0.5.1
     # via
@@ -293,13 +294,9 @@ mccabe==0.7.0
     #   pylint
 mock==5.1.0
     # via -r requirements/test.txt
-more-itertools==10.2.0
-    # via
-    #   -r requirements/test.txt
-    #   inflect
 mysqlclient==2.2.4
     # via -r requirements/test.txt
-newrelic==9.8.0
+newrelic==9.7.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -326,12 +323,12 @@ pbr==6.0.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-pillow==10.3.0
+pillow==10.2.0
     # via
     #   -r requirements/test.txt
     #   pillow-heif
     #   wagtail
-pillow-heif==0.16.0
+pillow-heif==0.15.0
     # via
     #   -r requirements/test.txt
     #   willow
@@ -350,10 +347,18 @@ psutil==5.9.8
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
-pycparser==2.22
+pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
+pydantic==2.6.4
+    # via
+    #   -r requirements/test.txt
+    #   inflect
+pydantic-core==2.16.3
+    # via
+    #   -r requirements/test.txt
+    #   pydantic
 pygments==2.17.2
     # via
     #   doc8
@@ -539,20 +544,18 @@ tomlkit==0.12.4
     #   pylint
 tox==4.14.2
     # via -r requirements/test.txt
-typeguard==4.2.1
-    # via
-    #   -r requirements/test.txt
-    #   inflect
 typing-extensions==4.10.0
     # via
     #   -r requirements/test.txt
+    #   annotated-types
     #   asgiref
     #   astroid
     #   edx-opaque-keys
     #   faker
     #   inflect
+    #   pydantic
+    #   pydantic-core
     #   pylint
-    #   typeguard
 uritemplate==4.1.1
     # via
     #   -r requirements/test.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -31,9 +31,9 @@ beautifulsoup4==4.12.3
     # via
     #   -r requirements/test.txt
     #   wagtail
-boto3==1.34.80
+boto3==1.34.75
     # via -r requirements/test.txt
-botocore==1.34.80
+botocore==1.34.75
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -70,7 +70,7 @@ click-log==0.4.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-code-annotations==1.8.0
+code-annotations==1.7.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -190,7 +190,7 @@ drf-yasg==1.21.7
     # via
     #   -r requirements/test.txt
     #   edx-api-doc-tools
-edx-api-doc-tools==1.8.0
+edx-api-doc-tools==1.7.0
     # via -r requirements/test.txt
 edx-auth-backends==4.3.0
     # via -r requirements/test.txt
@@ -223,7 +223,7 @@ exceptiongroup==1.2.0
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==24.7.1
+faker==24.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -543,7 +543,7 @@ typeguard==4.2.1
     # via
     #   -r requirements/test.txt
     #   inflect
-typing-extensions==4.11.0
+typing-extensions==4.10.0
     # via
     #   -r requirements/test.txt
     #   asgiref
@@ -566,7 +566,7 @@ virtualenv==20.25.1
     # via
     #   -r requirements/test.txt
     #   tox
-wagtail==6.0.2
+wagtail==6.0.1
     # via -r requirements/test.txt
 webencodings==0.5.1
     # via

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-build==1.2.1
+build==1.1.1
     # via pip-tools
 click==8.1.7
     # via pip-tools

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+annotated-types==0.6.0
+    # via
+    #   -r requirements/base.txt
+    #   pydantic
 anyascii==0.3.2
     # via
     #   -r requirements/base.txt
@@ -22,11 +26,11 @@ beautifulsoup4==4.12.3
     # via
     #   -r requirements/base.txt
     #   wagtail
-boto3==1.34.75
+boto3==1.34.70
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
-botocore==1.34.75
+botocore==1.34.70
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -140,16 +144,16 @@ drf-yasg==1.21.7
     #   edx-api-doc-tools
 edx-api-doc-tools==1.7.0
     # via -r requirements/base.txt
-edx-auth-backends==4.3.0
+edx-auth-backends==4.2.0
     # via -r requirements/base.txt
-edx-django-release-util==1.4.0
+edx-django-release-util==1.3.0
     # via -r requirements/base.txt
-edx-django-utils==5.12.0
+edx-django-utils==5.11.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==10.3.0
+edx-drf-extensions==10.2.0
     # via -r requirements/base.txt
 edx-opaque-keys==2.5.1
     # via
@@ -179,11 +183,7 @@ idna==3.6
     # via
     #   -r requirements/base.txt
     #   requests
-importlib-metadata==6.11.0
-    # via
-    #   -r requirements/base.txt
-    #   typeguard
-inflect==7.2.0
+inflect==7.0.0
     # via -r requirements/base.txt
 inflection==0.5.1
     # via
@@ -204,13 +204,9 @@ laces==0.1.1
     #   wagtail
 mock==5.1.0
     # via -r requirements/base.txt
-more-itertools==10.2.0
-    # via
-    #   -r requirements/base.txt
-    #   inflect
 mysqlclient==2.2.4
     # via -r requirements/base.txt
-newrelic==9.8.0
+newrelic==9.7.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -232,12 +228,12 @@ pbr==6.0.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-pillow==10.3.0
+pillow==10.2.0
     # via
     #   -r requirements/base.txt
     #   pillow-heif
     #   wagtail
-pillow-heif==0.16.0
+pillow-heif==0.15.0
     # via
     #   -r requirements/base.txt
     #   willow
@@ -245,10 +241,18 @@ psutil==5.9.8
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pycparser==2.22
+pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
+pydantic==2.6.4
+    # via
+    #   -r requirements/base.txt
+    #   inflect
+pydantic-core==2.16.3
+    # via
+    #   -r requirements/base.txt
+    #   pydantic
 pyjwt[crypto]==2.8.0
     # via
     #   -r requirements/base.txt
@@ -348,17 +352,15 @@ telepath==0.3.1
     # via
     #   -r requirements/base.txt
     #   wagtail
-typeguard==4.2.1
-    # via
-    #   -r requirements/base.txt
-    #   inflect
 typing-extensions==4.10.0
     # via
     #   -r requirements/base.txt
+    #   annotated-types
     #   asgiref
     #   edx-opaque-keys
     #   inflect
-    #   typeguard
+    #   pydantic
+    #   pydantic-core
 uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
@@ -379,9 +381,7 @@ willow[heif]==1.8.0
     #   -r requirements/base.txt
     #   wagtail
 zipp==3.18.1
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
+    # via -r requirements/base.txt
 zope-event==5.0
     # via gevent
 zope-interface==6.2

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -22,11 +22,11 @@ beautifulsoup4==4.12.3
     # via
     #   -r requirements/base.txt
     #   wagtail
-boto3==1.34.80
+boto3==1.34.75
     # via
     #   -r requirements/base.txt
     #   -r requirements/production.in
-botocore==1.34.80
+botocore==1.34.75
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -138,7 +138,7 @@ drf-yasg==1.21.7
     # via
     #   -r requirements/base.txt
     #   edx-api-doc-tools
-edx-api-doc-tools==1.8.0
+edx-api-doc-tools==1.7.0
     # via -r requirements/base.txt
 edx-auth-backends==4.3.0
     # via -r requirements/base.txt
@@ -352,7 +352,7 @@ typeguard==4.2.1
     # via
     #   -r requirements/base.txt
     #   inflect
-typing-extensions==4.11.0
+typing-extensions==4.10.0
     # via
     #   -r requirements/base.txt
     #   asgiref
@@ -368,7 +368,7 @@ urllib3==1.26.18
     #   -r requirements/base.txt
     #   botocore
     #   requests
-wagtail==6.0.2
+wagtail==6.0.1
     # via -r requirements/base.txt
 webencodings==0.5.1
     # via

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+annotated-types==0.6.0
+    # via
+    #   -r requirements/test.txt
+    #   pydantic
 anyascii==0.3.2
     # via
     #   -r requirements/test.txt
@@ -27,9 +31,9 @@ beautifulsoup4==4.12.3
     # via
     #   -r requirements/test.txt
     #   wagtail
-boto3==1.34.75
+boto3==1.34.70
     # via -r requirements/test.txt
-botocore==1.34.75
+botocore==1.34.70
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -180,16 +184,16 @@ drf-yasg==1.21.7
     #   edx-api-doc-tools
 edx-api-doc-tools==1.7.0
     # via -r requirements/test.txt
-edx-auth-backends==4.3.0
+edx-auth-backends==4.2.0
     # via -r requirements/test.txt
-edx-django-release-util==1.4.0
+edx-django-release-util==1.3.0
     # via -r requirements/test.txt
-edx-django-utils==5.12.0
+edx-django-utils==5.11.0
     # via
     #   -r requirements/test.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==10.3.0
+edx-drf-extensions==10.2.0
     # via -r requirements/test.txt
 edx-lint==5.3.6
     # via
@@ -232,11 +236,7 @@ idna==3.6
     # via
     #   -r requirements/test.txt
     #   requests
-importlib-metadata==6.11.0
-    # via
-    #   -r requirements/test.txt
-    #   typeguard
-inflect==7.2.0
+inflect==7.0.0
     # via -r requirements/test.txt
 inflection==0.5.1
     # via
@@ -278,13 +278,9 @@ mccabe==0.7.0
     #   pylint
 mock==5.1.0
     # via -r requirements/test.txt
-more-itertools==10.2.0
-    # via
-    #   -r requirements/test.txt
-    #   inflect
 mysqlclient==2.2.4
     # via -r requirements/test.txt
-newrelic==9.8.0
+newrelic==9.7.1
     # via
     #   -r requirements/test.txt
     #   edx-django-utils
@@ -308,12 +304,12 @@ pbr==6.0.0
     # via
     #   -r requirements/test.txt
     #   stevedore
-pillow==10.3.0
+pillow==10.2.0
     # via
     #   -r requirements/test.txt
     #   pillow-heif
     #   wagtail
-pillow-heif==0.16.0
+pillow-heif==0.15.0
     # via
     #   -r requirements/test.txt
     #   willow
@@ -334,10 +330,18 @@ psutil==5.9.8
     #   edx-django-utils
 pycodestyle==2.11.1
     # via -r requirements/quality.in
-pycparser==2.22
+pycparser==2.21
     # via
     #   -r requirements/test.txt
     #   cffi
+pydantic==2.6.4
+    # via
+    #   -r requirements/test.txt
+    #   inflect
+pydantic-core==2.16.3
+    # via
+    #   -r requirements/test.txt
+    #   pydantic
 pydocstyle==6.3.0
     # via -r requirements/quality.in
 pyjwt[crypto]==2.8.0
@@ -495,20 +499,18 @@ tomlkit==0.12.4
     #   pylint
 tox==4.14.2
     # via -r requirements/test.txt
-typeguard==4.2.1
-    # via
-    #   -r requirements/test.txt
-    #   inflect
 typing-extensions==4.10.0
     # via
     #   -r requirements/test.txt
+    #   annotated-types
     #   asgiref
     #   astroid
     #   edx-opaque-keys
     #   faker
     #   inflect
+    #   pydantic
+    #   pydantic-core
     #   pylint
-    #   typeguard
 uritemplate==4.1.1
     # via
     #   -r requirements/test.txt
@@ -533,6 +535,4 @@ willow[heif]==1.8.0
     #   -r requirements/test.txt
     #   wagtail
 zipp==3.18.1
-    # via
-    #   -r requirements/test.txt
-    #   importlib-metadata
+    # via -r requirements/test.txt

--- a/requirements/quality.txt
+++ b/requirements/quality.txt
@@ -27,9 +27,9 @@ beautifulsoup4==4.12.3
     # via
     #   -r requirements/test.txt
     #   wagtail
-boto3==1.34.80
+boto3==1.34.75
     # via -r requirements/test.txt
-botocore==1.34.80
+botocore==1.34.75
     # via
     #   -r requirements/test.txt
     #   boto3
@@ -66,7 +66,7 @@ click-log==0.4.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-code-annotations==1.8.0
+code-annotations==1.7.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -178,7 +178,7 @@ drf-yasg==1.21.7
     # via
     #   -r requirements/test.txt
     #   edx-api-doc-tools
-edx-api-doc-tools==1.8.0
+edx-api-doc-tools==1.7.0
     # via -r requirements/test.txt
 edx-auth-backends==4.3.0
     # via -r requirements/test.txt
@@ -211,7 +211,7 @@ exceptiongroup==1.2.0
     #   pytest
 factory-boy==3.3.0
     # via -r requirements/test.txt
-faker==24.7.1
+faker==24.4.0
     # via
     #   -r requirements/test.txt
     #   factory-boy
@@ -499,7 +499,7 @@ typeguard==4.2.1
     # via
     #   -r requirements/test.txt
     #   inflect
-typing-extensions==4.11.0
+typing-extensions==4.10.0
     # via
     #   -r requirements/test.txt
     #   asgiref
@@ -522,7 +522,7 @@ virtualenv==20.25.1
     # via
     #   -r requirements/test.txt
     #   tox
-wagtail==6.0.2
+wagtail==6.0.1
     # via -r requirements/test.txt
 webencodings==0.5.1
     # via

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,6 +4,10 @@
 #
 #    make upgrade
 #
+annotated-types==0.6.0
+    # via
+    #   -r requirements/base.txt
+    #   pydantic
 anyascii==0.3.2
     # via
     #   -r requirements/base.txt
@@ -26,9 +30,9 @@ beautifulsoup4==4.12.3
     # via
     #   -r requirements/base.txt
     #   wagtail
-boto3==1.34.75
+boto3==1.34.70
     # via -r requirements/base.txt
-botocore==1.34.75
+botocore==1.34.70
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -168,16 +172,16 @@ drf-yasg==1.21.7
     #   edx-api-doc-tools
 edx-api-doc-tools==1.7.0
     # via -r requirements/base.txt
-edx-auth-backends==4.3.0
+edx-auth-backends==4.2.0
     # via -r requirements/base.txt
-edx-django-release-util==1.4.0
+edx-django-release-util==1.3.0
     # via -r requirements/base.txt
-edx-django-utils==5.12.0
+edx-django-utils==5.11.0
     # via
     #   -r requirements/base.txt
     #   edx-drf-extensions
     #   edx-rest-api-client
-edx-drf-extensions==10.3.0
+edx-drf-extensions==10.2.0
     # via -r requirements/base.txt
 edx-lint==5.3.6
     # via -r requirements/test.in
@@ -217,12 +221,7 @@ idna==3.6
     # via
     #   -r requirements/base.txt
     #   requests
-importlib-metadata==6.11.0
-    # via
-    #   -c requirements/common_constraints.txt
-    #   -r requirements/base.txt
-    #   typeguard
-inflect==7.2.0
+inflect==7.0.0
     # via -r requirements/base.txt
 inflection==0.5.1
     # via
@@ -255,13 +254,9 @@ mock==5.1.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.in
-more-itertools==10.2.0
-    # via
-    #   -r requirements/base.txt
-    #   inflect
 mysqlclient==2.2.4
     # via -r requirements/base.txt
-newrelic==9.8.0
+newrelic==9.7.1
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
@@ -285,12 +280,12 @@ pbr==6.0.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-pillow==10.3.0
+pillow==10.2.0
     # via
     #   -r requirements/base.txt
     #   pillow-heif
     #   wagtail
-pillow-heif==0.16.0
+pillow-heif==0.15.0
     # via
     #   -r requirements/base.txt
     #   willow
@@ -307,10 +302,18 @@ psutil==5.9.8
     # via
     #   -r requirements/base.txt
     #   edx-django-utils
-pycparser==2.22
+pycparser==2.21
     # via
     #   -r requirements/base.txt
     #   cffi
+pydantic==2.6.4
+    # via
+    #   -r requirements/base.txt
+    #   inflect
+pydantic-core==2.16.3
+    # via
+    #   -r requirements/base.txt
+    #   pydantic
 pyjwt[crypto]==2.8.0
     # via
     #   -r requirements/base.txt
@@ -449,20 +452,18 @@ tomlkit==0.12.4
     # via pylint
 tox==4.14.2
     # via -r requirements/test.in
-typeguard==4.2.1
-    # via
-    #   -r requirements/base.txt
-    #   inflect
 typing-extensions==4.10.0
     # via
     #   -r requirements/base.txt
+    #   annotated-types
     #   asgiref
     #   astroid
     #   edx-opaque-keys
     #   faker
     #   inflect
+    #   pydantic
+    #   pydantic-core
     #   pylint
-    #   typeguard
 uritemplate==4.1.1
     # via
     #   -r requirements/base.txt
@@ -485,6 +486,4 @@ willow[heif]==1.8.0
     #   -r requirements/base.txt
     #   wagtail
 zipp==3.18.1
-    # via
-    #   -r requirements/base.txt
-    #   importlib-metadata
+    # via -r requirements/base.txt

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -26,9 +26,9 @@ beautifulsoup4==4.12.3
     # via
     #   -r requirements/base.txt
     #   wagtail
-boto3==1.34.80
+boto3==1.34.75
     # via -r requirements/base.txt
-botocore==1.34.80
+botocore==1.34.75
     # via
     #   -r requirements/base.txt
     #   boto3
@@ -59,7 +59,7 @@ click==8.1.7
     #   edx-lint
 click-log==0.4.0
     # via edx-lint
-code-annotations==1.8.0
+code-annotations==1.7.0
     # via
     #   -r requirements/test.in
     #   edx-lint
@@ -166,7 +166,7 @@ drf-yasg==1.21.7
     # via
     #   -r requirements/base.txt
     #   edx-api-doc-tools
-edx-api-doc-tools==1.8.0
+edx-api-doc-tools==1.7.0
     # via -r requirements/base.txt
 edx-auth-backends==4.3.0
     # via -r requirements/base.txt
@@ -197,7 +197,7 @@ exceptiongroup==1.2.0
     # via pytest
 factory-boy==3.3.0
     # via -r requirements/test.in
-faker==24.7.1
+faker==24.4.0
     # via
     #   -r requirements/test.in
     #   factory-boy
@@ -453,7 +453,7 @@ typeguard==4.2.1
     # via
     #   -r requirements/base.txt
     #   inflect
-typing-extensions==4.11.0
+typing-extensions==4.10.0
     # via
     #   -r requirements/base.txt
     #   asgiref
@@ -474,7 +474,7 @@ urllib3==1.26.18
     #   requests
 virtualenv==20.25.1
     # via tox
-wagtail==6.0.2
+wagtail==6.0.1
     # via -r requirements/base.txt
 webencodings==0.5.1
     # via


### PR DESCRIPTION
### Description

**Jira**: [COSMO-255](https://2u-internal.atlassian.net/browse/COSMO-255) (private)

This pull request reverts the following two commits.

* d91d943c1b6fae15274e1a8fb24252c0325068a8
* e8883bdbfb271cbf1810b8b5eced7723233be16d

Starting 04/05/2024, deployments of this service started to fail due to failing migrations on the wagtail core model in the wagtail application. We are reverting the code changes up until the issue began to rule out an issue in any of our Python requirements upgrade, namely the upgrade of wagtail from `6.0.1` to `6.0.2`.