### PR TITLE
Fix broken mysql8-migrations-check workflow due to python-xmlsec.

### DIFF
--- a/.github/workflows/mysql8-migrations-check.yml
+++ b/.github/workflows/mysql8-migrations-check.yml
@@ -53,7 +53,7 @@ jobs:
         pip uninstall -y mysqlclient
         pip install --no-binary mysqlclient mysqlclient
         pip uninstall -y xmlsec
-        pip install --no-binary xmlsec xmlsec
+        pip install --no-binary xmlsec xmlsec==1.3.13
     - name: Initiate services
       run: |
         sudo /etc/init.d/mysql start


### PR DESCRIPTION
### Description

The latest version of `python-xmlsec` is breaking the `mysql8-migrations` Github action. See [issue #314](https://github.com/xmlsec/python-xmlsec/issues/314).

The recommended course of action is to pin the version of `python-xmlsec` in the action.