### PR TITLE
build: replace codecov

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = True
 data_file = .coverage
+relative_files = True
 source=designer
 omit =
     designer/settings*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,4 +30,10 @@ jobs:
       run: tox
     - name: Codecov
       if: matrix.python-version == '3.8' && matrix.toxenv == 'django42'
-      uses: codecov/codecov-action@v2
+      uses: py-cov-action/python-coverage-comment-action@v3
+      with:
+        GITHUB_TOKEN: ${{ github.token }}
+        MINIMUM_GREEN: 95
+        MINIMUM_ORANGE: 84
+        ANNOTATE_MISSING_LINES: true
+        ANNOTATION_TYPE: error


### PR DESCRIPTION
**JIRA:** [COSMO-267](https://2u-internal.atlassian.net/browse/COSMO-267?atlOrigin=eyJpIjoiM2Y3YjExN2ZkMGRiNDQ3Nzk2OGFjNzUxOTYxMzA3NWIiLCJwIjoiaiJ9)

**Description:** Replaces the use of codecov with python-coverage-comment, which is the tool used in other private repositories.