### PR TITLE
fix: replace deprecated set-output

### DIFF
--- a/.github/workflows/mysql8-migrations-check.yml
+++ b/.github/workflows/mysql8-migrations-check.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache-dir
       run: |
-        echo "dir=$(pip cache dir)"
+        echo "dir=$(pip cache dir)" >> $GITHUB_OUTPUT
     - name: Cache pip dependencies
       id: cache-dependencies
       uses: actions/cache@v2

--- a/.github/workflows/mysql8-migrations-check.yml
+++ b/.github/workflows/mysql8-migrations-check.yml
@@ -33,7 +33,7 @@ jobs:
     - name: Get pip cache dir
       id: pip-cache-dir
       run: |
-        echo "::set-output name=dir::$(pip cache dir)"
+        echo "dir=$(pip cache dir)"
     - name: Cache pip dependencies
       id: cache-dependencies
       uses: actions/cache@v2


### PR DESCRIPTION
## Description
- `set-output` has been deprecated by GitHub and it is suggested to be replaced by GitHub.